### PR TITLE
[Extension] DELETE_BOOKMARK ハンドラの実装

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -15,6 +15,7 @@ import {
   INVALID_URLS,
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_2,
+  MOCK_BOOKMARK_ENTITY_1,
   MOCK_IDS,
   TEST_STRINGS,
   VALID_URLS,
@@ -468,6 +469,97 @@ describe('background service worker', () => {
     })
   })
 
+  describe('統合メッセージディスパッチャ (DELETE_BOOKMARK)', () => {
+    beforeEach(async () => {
+      await loadBookmarks([MOCK_BOOKMARK_1])
+    })
+
+    describe('正常終了', () => {
+      it.each([
+        {
+          name: '登録済みのIDを指定',
+          id: MOCK_BOOKMARK_1.id,
+          count: 0,
+          getResult: undefined,
+        },
+        {
+          name: '未登録のIDを指定',
+          id: MOCK_BOOKMARK_2.id,
+          count: 1,
+          getResult: MOCK_BOOKMARK_ENTITY_1,
+        },
+      ])('$name', async ({ id, count, getResult }) => {
+        await import('./background')
+
+        const sendResponse = vi.fn()
+
+        vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+          {
+            action: API_ACTIONS.DELETE_BOOKMARK,
+            payload: {
+              id,
+            },
+          },
+          {},
+          sendResponse,
+        )
+
+        await vi.waitFor(() => {
+          expect(sendResponse).toHaveBeenCalledWith(
+            expect.objectContaining({
+              success: true,
+              data: null,
+            }),
+          )
+        })
+
+        expect(await db.bookmarks.count()).toBe(count)
+        expect(await db.bookmarks.get(id)).toEqual(undefined)
+        expect(await db.bookmarks.get(MOCK_BOOKMARK_1.id)).toEqual(getResult)
+      })
+    })
+
+    describe('異常終了', () => {
+      it.each([
+        { name: 'ID を指定しない場合', payload: {} },
+        {
+          name: '不正な ID 形式の場合',
+          payload: { id: TEST_STRINGS.INVALID_ID },
+        },
+      ])('$name', async ({ payload }) => {
+        await import('./background')
+
+        const sendResponse = vi.fn()
+
+        vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+          {
+            action: API_ACTIONS.DELETE_BOOKMARK,
+            payload,
+          },
+          {},
+          sendResponse,
+        )
+
+        await vi.waitFor(() => {
+          expect(sendResponse).toHaveBeenCalledWith(
+            expect.objectContaining({
+              success: false,
+              error: {
+                code: ERROR_CODES.BAD_REQUEST,
+                message: expect.stringContaining('Invalid payload'),
+              },
+            }),
+          )
+        })
+
+        expect(await db.bookmarks.count()).toBe(1)
+        expect(await db.bookmarks.get(MOCK_BOOKMARK_1.id)).toEqual(
+          MOCK_BOOKMARK_ENTITY_1,
+        )
+      })
+    })
+  })
+
   describe('未実装のメッセージ', () => {
     it.each([
       {
@@ -476,12 +568,6 @@ describe('background service worker', () => {
           id: MOCK_BOOKMARK_1.id,
           url: MOCK_BOOKMARK_1.url,
           title: MOCK_BOOKMARK_1.title,
-        },
-      },
-      {
-        action: API_ACTIONS.DELETE_BOOKMARK,
-        payload: {
-          id: MOCK_BOOKMARK_1.id,
         },
       },
       {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -192,8 +192,16 @@ const handleApiMessage = async (
         }
       }
 
+      case API_ACTIONS.DELETE_BOOKMARK: {
+        await db.deleteBookmark(request.payload.id)
+
+        return {
+          success: true,
+          data: null,
+        }
+      }
+
       case API_ACTIONS.UPDATE_BOOKMARK:
-      case API_ACTIONS.DELETE_BOOKMARK:
       case API_ACTIONS.REORDER_BOOKMARKS:
 
       // キーワード操作

--- a/extension/src/lib/bookmark-idb.test.ts
+++ b/extension/src/lib/bookmark-idb.test.ts
@@ -141,21 +141,33 @@ describe('BookmarkDatabase - Bookmark Operations', () => {
   })
 
   describe('Delete', () => {
-    it('deleteBookmark が正常にブックマークを削除すること', async () => {
+    describe('正常終了', () => {
       const bookmark = MOCK_BOOKMARK_ENTITY_1
-      await db.bookmarks.add(bookmark)
-
-      await db.deleteBookmark(bookmark.id)
-
-      const deleted = await db.bookmarks.get(bookmark.id)
-      expect(deleted).toBeUndefined()
-    })
-
-    it('存在しない ID の削除を試みた場合にエラーを投げること', async () => {
       const unknownId = BookmarkIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
-      await expect(db.deleteBookmark(unknownId)).rejects.toThrow(
-        ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
-      )
+
+      beforeEach(async () => {
+        await db.bookmarks.clear()
+        await db.bookmarks.add(bookmark)
+      })
+      it.each([
+        {
+          name: '登録済みのブックマークID',
+          id: bookmark.id,
+          count: 0,
+          getResult: undefined,
+        },
+        {
+          name: '未登録のブックマークID',
+          id: unknownId,
+          count: 1,
+          getResult: bookmark,
+        },
+      ])('$name', async ({ id, count, getResult }) => {
+        expect(await db.deleteBookmark(id)).toBeUndefined()
+        expect(await db.bookmarks.count()).toBe(count)
+        expect(await db.bookmarks.get(id)).toEqual(undefined)
+        expect(await db.bookmarks.get(bookmark.id)).toEqual(getResult)
+      })
     })
 
     it('不正な形式の ID での削除を試みた場合にバリデーションエラーを投げること', async () => {

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -127,7 +127,7 @@ export class BookmarkDatabase extends Dexie {
         // 存在確認
         const bookmark = await this.bookmarks.get(validatedId)
         if (!bookmark) {
-          throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+          return
         }
 
         // ブックマークを削除


### PR DESCRIPTION
Issue #479
統合メッセージディスパッチャにおいて `DELETE_BOOKMARK` アクションをサポートし、IndexedDB からブックマークを削除するハンドラを実装しました。

## 変更内容
- `extension/src/background.ts`:
    - `handleApiMessage` 内に `DELETE_BOOKMARK` ハンドラを実装。
    - 削除処理の成功時に `data: null` を返送する形式を採用。
- `extension/src/lib/idb.ts`:
    - `deleteBookmark` メソッドを、存在しない ID に対しても例外を投げず正常終了する「冪等（べきとう）」な設計に改善。
- `extension/src/background.test.ts`:
    - TDD サイクルに基づき、正常系（登録済み・未登録ID）および異常系（バリデーションエラー）のテストを追加。
    - 異常系テストにおいて、既存データが意図せず削除されないこと（不変性）を検証するアサーションを追加。

これにより、UI 側から安全にブックマークを削除できる基盤が整いました。