### PR TITLE
[Extension] メッセージディスパッチャの冗長なバリデーション削除

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -302,7 +302,9 @@ describe('background service worker', () => {
             success: false,
             error: expect.objectContaining({
               code: ERROR_CODES.BAD_REQUEST,
-              message: expect.stringContaining('Invalid payload: '),
+              message: expect.stringContaining(
+                LOG_MESSAGES.INVALID_PAYLOAD(''),
+              ),
             }),
           }),
         )
@@ -417,7 +419,7 @@ describe('background service worker', () => {
           payload: { title: '', url: MOCK_BOOKMARK_2.url },
           error: {
             code: ERROR_CODES.BAD_REQUEST,
-            message: expect.stringContaining('Invalid payload'),
+            message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
           },
         },
         {
@@ -425,7 +427,7 @@ describe('background service worker', () => {
           payload: { url: MOCK_BOOKMARK_2.url },
           error: {
             code: ERROR_CODES.BAD_REQUEST,
-            message: expect.stringContaining('Invalid payload'),
+            message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
           },
         },
         {
@@ -436,7 +438,7 @@ describe('background service worker', () => {
           },
           error: {
             code: ERROR_CODES.BAD_REQUEST,
-            message: expect.stringContaining('Invalid payload'),
+            message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
           },
         },
       ])('$name', async ({ payload, error }) => {
@@ -546,7 +548,9 @@ describe('background service worker', () => {
               success: false,
               error: {
                 code: ERROR_CODES.BAD_REQUEST,
-                message: expect.stringContaining('Invalid payload'),
+                message: expect.stringContaining(
+                  LOG_MESSAGES.INVALID_PAYLOAD(''),
+                ),
               },
             }),
           )

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -8,10 +8,8 @@ import {
 } from '@shared/constants'
 import {
   ApiRequestSchema,
-  createBookmarkRequestSchema,
   type ApiRequest,
   type ApiError,
-  readBookmarkStatusRequestSchema,
 } from '@shared/schemas/api'
 
 import { determineBookmarkStatus } from './lib/bookmark-utils'
@@ -114,24 +112,11 @@ const handleApiMessage = async (
       }
 
       case API_ACTIONS.CREATE_BOOKMARK: {
-        // 1. バリデーション
-        const validation = createBookmarkRequestSchema.safeParse(request)
-        if (!validation.success) {
-          return {
-            success: false,
-            error: {
-              message: LOG_MESSAGES.INVALID_PAYLOAD(validation.error.message),
-              code: ERROR_CODES.BAD_REQUEST,
-            },
-          }
-        }
-
-        // 2. 保存処理（db.createBookmark は BookmarkId を返します）
-        const { title, url } = validation.data.payload
         try {
-          const bookmarkId = await db.createBookmark({ title, url })
-          // 3. 作成された完全なデータを取得して返送（キーワード情報などを含めるため）
-          const newBookmark = await db.bookmarks.get(bookmarkId)
+          // 作成された完全なデータを取得して返送（キーワード情報などを含めるため）
+          const newBookmark = await db.bookmarks.get(
+            await db.createBookmark(request.payload),
+          )
           if (!newBookmark) {
             throw new Error(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
           }
@@ -167,22 +152,7 @@ const handleApiMessage = async (
         }
       }
       case API_ACTIONS.READ_BOOKMARK_STATUS: {
-        // 1. 個別のスキーマでパース（safeParse を推奨）
-        const validation = readBookmarkStatusRequestSchema.safeParse(request)
-
-        // 2. バリデーション失敗時のエラーレスポンス
-        if (!validation.success) {
-          return {
-            success: false,
-            error: {
-              message: LOG_MESSAGES.INVALID_PAYLOAD(validation.error.message),
-              code: ERROR_CODES.BAD_REQUEST, // ここが重要
-            },
-          }
-        }
-
-        // 3. 成功時の処理（validation.data.payload を安全に使用できる）
-        const { url, title } = validation.data.payload
+        const { url, title } = request.payload
         const bookmark = await db.bookmarks.where('url').equals(url).first()
         const status = determineBookmarkStatus(bookmark?.title, title)
 


### PR DESCRIPTION
Issue #481
`extension/src/background.ts` の `handleApiMessage` において、各アクション内で行われていた個別の `safeParse` によるバリデーションを削除しました。

## 変更内容
- `extension/src/background.ts`:
    - `CREATE_BOOKMARK`, `READ_BOOKMARK_STATUS` 内の個別のパース処理を削除し、`request.payload` を直接使用するように変更。
    - 呼び出し元の `onMessage` リスナーによる検証（`ApiRequestSchema`）を信頼し、TypeScript の型絞り込みを活用。
- `extension/src/background.test.ts`:
    - バリデーションエラーメッセージの検証を、アクション固有のものから共通の `LOG_MESSAGES.INVALID_PAYLOAD('')` を参照する形式に統一。

これにより、ハンドラごとのロジックが簡素化され、メンテナンス性が向上しました。