### PR TITLE
[Extension] background.test.ts の分割と整理

### DIFF
--- a/extension/src/background.bookmark.test.ts
+++ b/extension/src/background.bookmark.test.ts
@@ -7,21 +7,18 @@ import {
   BOOKMARK_STATUS,
   ERROR_CODES,
   ERROR_MESSAGES,
-  EXTENSION_ICONS,
   LOG_MESSAGES,
 } from '@shared/constants'
-import type { Bookmark } from '@shared/schemas/bookmark'
 import {
   INVALID_URLS,
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_2,
   MOCK_BOOKMARK_3,
   MOCK_BOOKMARK_ENTITY_1,
-  MOCK_IDS,
   TEST_STRINGS,
-  VALID_URLS,
 } from '@shared/test/fixtures'
 
+import { loadBookmarks } from './background.test.utils'
 import { db } from './lib/idb'
 
 describe('background service worker', () => {
@@ -58,149 +55,6 @@ describe('background service worker', () => {
 
     // background.ts を再読み込み
     vi.resetModules()
-  })
-
-  const loadBookmarks = async (bookmarks: Bookmark[]) => {
-    await db.bookmarks.clear()
-    for (const [index, b] of bookmarks.entries()) {
-      await db.bookmarks.add({
-        id: b.id,
-        title: b.title,
-        url: b.url,
-        sortOrder: index,
-        keywordIds: b.keywords.map((k) => k.id), // キーワードIDも反映
-      })
-    }
-  }
-
-  it('拡張機能インストール時にログを出力すること', async () => {
-    const consoleSpy = vi.mocked(console.log)
-    const addListenerMock = vi.mocked(chrome.runtime.onInstalled.addListener)
-
-    await import('./background')
-    expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.BACKGROUND_LOADED)
-
-    const callback = addListenerMock.mock.calls[0][0]
-    callback({ reason: 'install' } as chrome.runtime.InstalledDetails)
-
-    expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.EXTENSION_INSTALLED)
-  })
-
-  describe('アイコン状態更新 (updateIconStatus)', () => {
-    beforeEach(async () => {
-      // 3. テストに必要なデータをあらかじめ DB に入れておく（これが「スタブ」の代わり）
-      // 例：URL が登録済みの状態をテストしたい場合
-      await loadBookmarks([MOCK_BOOKMARK_1])
-    })
-
-    it('未登録の URL の場合にデフォルトアイコンをセットすること', async () => {
-      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
-      await import('./background')
-
-      const handler = onUpdatedMock.mock.calls[0][0]
-      handler(1, { status: 'complete' }, {
-        url: VALID_URLS.GOOGLE,
-        title: TEST_STRINGS.NEW_NAME,
-      } as chrome.tabs.Tab)
-
-      await vi.waitFor(() => {
-        expect(chrome.action.setIcon).toHaveBeenCalledWith({
-          tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE],
-        })
-      })
-    })
-
-    it('登録済みかつタイトル一致の場合に REGISTERED アイコンをセットすること', async () => {
-      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
-      await import('./background')
-
-      const handler = onUpdatedMock.mock.calls[0][0]
-      handler(1, { status: 'complete' }, {
-        url: MOCK_BOOKMARK_1.url,
-        title: MOCK_BOOKMARK_1.title,
-      } as chrome.tabs.Tab)
-
-      await vi.waitFor(() => {
-        expect(chrome.action.setIcon).toHaveBeenCalledWith({
-          tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.REGISTERED],
-        })
-      })
-    })
-
-    it('登録済みだがタイトル不一致の場合に MODIFIED アイコンをセットすること', async () => {
-      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
-      await import('./background')
-
-      const handler = onUpdatedMock.mock.calls[0][0]
-      handler(1, { status: 'complete' }, {
-        url: MOCK_BOOKMARK_1.url,
-        title: TEST_STRINGS.NEW_NAME,
-      } as chrome.tabs.Tab)
-
-      await vi.waitFor(() => {
-        expect(chrome.action.setIcon).toHaveBeenCalledWith({
-          tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.MODIFIED],
-        })
-      })
-    })
-
-    it('http 以外のプロトコルの場合に NONE アイコンをセットすること', async () => {
-      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
-      await import('./background')
-
-      const handler = onUpdatedMock.mock.calls[0][0]
-      handler(1, { status: 'complete' }, {
-        url: VALID_URLS.CHROME_SETTING,
-        title: TEST_STRINGS.NEW_NAME,
-      } as chrome.tabs.Tab)
-
-      await vi.waitFor(() => {
-        expect(chrome.action.setIcon).toHaveBeenCalledWith({
-          tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE],
-        })
-      })
-    })
-
-    it('タブのアクティブ化 (onActivated) 時にアイコンを更新すること', async () => {
-      const onActivatedMock = vi.mocked(chrome.tabs.onActivated.addListener)
-      const tabData = {
-        id: 1,
-        url: MOCK_BOOKMARK_1.url,
-        title: MOCK_BOOKMARK_1.title,
-      }
-      vi.mocked(chrome.tabs.get).mockImplementation((_id, callback) => {
-        if (callback) (callback as unknown as (tab: unknown) => void)(tabData)
-        return Promise.resolve(tabData as unknown as chrome.tabs.Tab)
-      })
-
-      await import('./background')
-
-      const handler = onActivatedMock.mock.calls[0][0]
-      handler({ tabId: 1, windowId: 1 })
-
-      expect(chrome.tabs.get).toHaveBeenCalledWith(1)
-
-      await vi.waitFor(() => {
-        expect(chrome.action.setIcon).toHaveBeenCalledWith({
-          tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.REGISTERED],
-        })
-      })
-    })
-
-    it('タブのアクティブ化時に tabs.get が失敗してもエラーを投げないこと', async () => {
-      const onActivatedMock = vi.mocked(chrome.tabs.onActivated.addListener)
-      vi.mocked(chrome.tabs.get).mockRejectedValue(new Error('Tab not found'))
-
-      await import('./background')
-
-      const handler = onActivatedMock.mock.calls[0][0]
-      await expect(handler({ tabId: 1, windowId: 1 })).resolves.not.toThrow()
-    })
   })
 
   describe('統合メッセージディスパッチャ (READ_BOOKMARK_STATUS)', () => {
@@ -701,45 +555,8 @@ describe('background service worker', () => {
     })
   })
 
-  describe('未実装のメッセージ', () => {
-    it.each([
-      {
-        action: API_ACTIONS.REORDER_BOOKMARKS,
-        payload: {
-          ids: [MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id],
-        },
-      },
-      {
-        action: API_ACTIONS.READ_KEYWORDS,
-        payload: undefined,
-      },
-      {
-        action: API_ACTIONS.CREATE_KEYWORD,
-        payload: { name: TEST_STRINGS.NEW_NAME },
-      },
-      {
-        action: API_ACTIONS.UPDATE_KEYWORD,
-        payload: { name: TEST_STRINGS.NEW_NAME, id: MOCK_IDS.KEYWORD_1 },
-      },
-      {
-        action: API_ACTIONS.DELETE_KEYWORD,
-        payload: { id: MOCK_IDS.KEYWORD_1 },
-      },
-      {
-        action: API_ACTIONS.ATTACH_KEYWORD,
-        payload: {
-          keywordId: MOCK_IDS.KEYWORD_1,
-          bookmarkId: MOCK_IDS.BOOKMARK_1,
-        },
-      },
-      {
-        action: API_ACTIONS.DETACH_KEYWORD,
-        payload: {
-          keywordId: MOCK_IDS.KEYWORD_1,
-          bookmarkId: MOCK_IDS.BOOKMARK_1,
-        },
-      },
-    ])('$action', async ({ action, payload }) => {
+  describe('統合メッセージディスパッチャ (REORDER_BOOKMARKS)', () => {
+    it('未実装の確認', async () => {
       const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
       await import('./background')
 
@@ -748,8 +565,10 @@ describe('background service worker', () => {
 
       messageHandler(
         {
-          action,
-          payload,
+          action: API_ACTIONS.REORDER_BOOKMARKS,
+          payload: {
+            ids: [MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id],
+          },
         },
         {},
         sendResponse,
@@ -760,7 +579,9 @@ describe('background service worker', () => {
           expect.objectContaining({
             success: false,
             error: {
-              message: LOG_MESSAGES.ACTION_NOT_IMPLEMENTED(action),
+              message: LOG_MESSAGES.ACTION_NOT_IMPLEMENTED(
+                API_ACTIONS.REORDER_BOOKMARKS,
+              ),
               code: ERROR_CODES.INTERNAL_SERVER_ERROR,
             },
           }),

--- a/extension/src/background.icon.test.ts
+++ b/extension/src/background.icon.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import 'fake-indexeddb/auto'
+
+import {
+  BOOKMARK_STATUS,
+  EXTENSION_ICONS,
+  LOG_MESSAGES,
+} from '@shared/constants'
+import {
+  MOCK_BOOKMARK_1,
+  TEST_STRINGS,
+  VALID_URLS,
+} from '@shared/test/fixtures'
+
+import { loadBookmarks } from './background.test.utils'
+
+describe('background service worker', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // chrome API のモックを再定義
+    vi.stubGlobal('chrome', {
+      runtime: {
+        onInstalled: { addListener: vi.fn() },
+        onMessage: { addListener: vi.fn() },
+      },
+      tabs: {
+        onUpdated: { addListener: vi.fn() },
+        onActivated: { addListener: vi.fn() },
+        get: vi.fn(),
+        query: vi.fn(),
+      },
+      storage: {
+        sync: {
+          get: vi.fn(),
+          set: vi.fn(),
+        },
+        onChanged: { addListener: vi.fn() },
+      },
+      action: {
+        setIcon: vi.fn(),
+      },
+    })
+
+    // background.ts を再読み込み
+    vi.resetModules()
+  })
+
+  it('拡張機能インストール時にログを出力すること', async () => {
+    const consoleSpy = vi.mocked(console.log)
+    const addListenerMock = vi.mocked(chrome.runtime.onInstalled.addListener)
+
+    await import('./background')
+    expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.BACKGROUND_LOADED)
+
+    const callback = addListenerMock.mock.calls[0][0]
+    callback({ reason: 'install' } as chrome.runtime.InstalledDetails)
+
+    expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.EXTENSION_INSTALLED)
+  })
+
+  describe('アイコン状態更新 (updateIconStatus)', () => {
+    beforeEach(async () => {
+      // 3. テストに必要なデータをあらかじめ DB に入れておく（これが「スタブ」の代わり）
+      // 例：URL が登録済みの状態をテストしたい場合
+      await loadBookmarks([MOCK_BOOKMARK_1])
+    })
+
+    it('未登録の URL の場合にデフォルトアイコンをセットすること', async () => {
+      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
+      await import('./background')
+
+      const handler = onUpdatedMock.mock.calls[0][0]
+      handler(1, { status: 'complete' }, {
+        url: VALID_URLS.GOOGLE,
+        title: TEST_STRINGS.NEW_NAME,
+      } as chrome.tabs.Tab)
+
+      await vi.waitFor(() => {
+        expect(chrome.action.setIcon).toHaveBeenCalledWith({
+          tabId: 1,
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE],
+        })
+      })
+    })
+
+    it('登録済みかつタイトル一致の場合に REGISTERED アイコンをセットすること', async () => {
+      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
+      await import('./background')
+
+      const handler = onUpdatedMock.mock.calls[0][0]
+      handler(1, { status: 'complete' }, {
+        url: MOCK_BOOKMARK_1.url,
+        title: MOCK_BOOKMARK_1.title,
+      } as chrome.tabs.Tab)
+
+      await vi.waitFor(() => {
+        expect(chrome.action.setIcon).toHaveBeenCalledWith({
+          tabId: 1,
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.REGISTERED],
+        })
+      })
+    })
+
+    it('登録済みだがタイトル不一致の場合に MODIFIED アイコンをセットすること', async () => {
+      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
+      await import('./background')
+
+      const handler = onUpdatedMock.mock.calls[0][0]
+      handler(1, { status: 'complete' }, {
+        url: MOCK_BOOKMARK_1.url,
+        title: TEST_STRINGS.NEW_NAME,
+      } as chrome.tabs.Tab)
+
+      await vi.waitFor(() => {
+        expect(chrome.action.setIcon).toHaveBeenCalledWith({
+          tabId: 1,
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.MODIFIED],
+        })
+      })
+    })
+
+    it('http 以外のプロトコルの場合に NONE アイコンをセットすること', async () => {
+      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
+      await import('./background')
+
+      const handler = onUpdatedMock.mock.calls[0][0]
+      handler(1, { status: 'complete' }, {
+        url: VALID_URLS.CHROME_SETTING,
+        title: TEST_STRINGS.NEW_NAME,
+      } as chrome.tabs.Tab)
+
+      await vi.waitFor(() => {
+        expect(chrome.action.setIcon).toHaveBeenCalledWith({
+          tabId: 1,
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE],
+        })
+      })
+    })
+
+    it('タブのアクティブ化 (onActivated) 時にアイコンを更新すること', async () => {
+      const onActivatedMock = vi.mocked(chrome.tabs.onActivated.addListener)
+      const tabData = {
+        id: 1,
+        url: MOCK_BOOKMARK_1.url,
+        title: MOCK_BOOKMARK_1.title,
+      }
+      vi.mocked(chrome.tabs.get).mockImplementation((_id, callback) => {
+        if (callback) (callback as unknown as (tab: unknown) => void)(tabData)
+        return Promise.resolve(tabData as unknown as chrome.tabs.Tab)
+      })
+
+      await import('./background')
+
+      const handler = onActivatedMock.mock.calls[0][0]
+      handler({ tabId: 1, windowId: 1 })
+
+      expect(chrome.tabs.get).toHaveBeenCalledWith(1)
+
+      await vi.waitFor(() => {
+        expect(chrome.action.setIcon).toHaveBeenCalledWith({
+          tabId: 1,
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.REGISTERED],
+        })
+      })
+    })
+
+    it('タブのアクティブ化時に tabs.get が失敗してもエラーを投げないこと', async () => {
+      const onActivatedMock = vi.mocked(chrome.tabs.onActivated.addListener)
+      vi.mocked(chrome.tabs.get).mockRejectedValue(new Error('Tab not found'))
+
+      await import('./background')
+
+      const handler = onActivatedMock.mock.calls[0][0]
+      await expect(handler({ tabId: 1, windowId: 1 })).resolves.not.toThrow()
+    })
+  })
+})

--- a/extension/src/background.keyword.test.ts
+++ b/extension/src/background.keyword.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import 'fake-indexeddb/auto'
+
+import { API_ACTIONS, ERROR_CODES, LOG_MESSAGES } from '@shared/constants'
+import { MOCK_IDS, TEST_STRINGS } from '@shared/test/fixtures'
+
+describe('background service worker', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // chrome API のモックを再定義
+    vi.stubGlobal('chrome', {
+      runtime: {
+        onInstalled: { addListener: vi.fn() },
+        onMessage: { addListener: vi.fn() },
+      },
+      tabs: {
+        onUpdated: { addListener: vi.fn() },
+        onActivated: { addListener: vi.fn() },
+        get: vi.fn(),
+        query: vi.fn(),
+      },
+      storage: {
+        sync: {
+          get: vi.fn(),
+          set: vi.fn(),
+        },
+        onChanged: { addListener: vi.fn() },
+      },
+      action: {
+        setIcon: vi.fn(),
+      },
+    })
+
+    // background.ts を再読み込み
+    vi.resetModules()
+  })
+
+  describe('未実装のメッセージ', () => {
+    it.each([
+      {
+        action: API_ACTIONS.READ_KEYWORDS,
+        payload: undefined,
+      },
+      {
+        action: API_ACTIONS.CREATE_KEYWORD,
+        payload: { name: TEST_STRINGS.NEW_NAME },
+      },
+      {
+        action: API_ACTIONS.UPDATE_KEYWORD,
+        payload: { name: TEST_STRINGS.NEW_NAME, id: MOCK_IDS.KEYWORD_1 },
+      },
+      {
+        action: API_ACTIONS.DELETE_KEYWORD,
+        payload: { id: MOCK_IDS.KEYWORD_1 },
+      },
+      {
+        action: API_ACTIONS.ATTACH_KEYWORD,
+        payload: {
+          keywordId: MOCK_IDS.KEYWORD_1,
+          bookmarkId: MOCK_IDS.BOOKMARK_1,
+        },
+      },
+      {
+        action: API_ACTIONS.DETACH_KEYWORD,
+        payload: {
+          keywordId: MOCK_IDS.KEYWORD_1,
+          bookmarkId: MOCK_IDS.BOOKMARK_1,
+        },
+      },
+    ])('$action', async ({ action, payload }) => {
+      const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
+      await import('./background')
+
+      const messageHandler = addListenerMock.mock.calls[0][0]
+      const sendResponse = vi.fn()
+
+      messageHandler(
+        {
+          action,
+          payload,
+        },
+        {},
+        sendResponse,
+      )
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: {
+              message: LOG_MESSAGES.ACTION_NOT_IMPLEMENTED(action),
+              code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+            },
+          }),
+        )
+      })
+    })
+  })
+})

--- a/extension/src/background.test.utils.ts
+++ b/extension/src/background.test.utils.ts
@@ -1,0 +1,19 @@
+import type { Bookmark } from '@shared/schemas/bookmark'
+
+import { db } from './lib/idb'
+
+/**
+ * テスト用のブックマークデータを IndexedDB に投入する
+ */
+export const loadBookmarks = async (bookmarks: Bookmark[]) => {
+  await db.bookmarks.clear()
+  for (const [index, b] of bookmarks.entries()) {
+    await db.bookmarks.add({
+      id: b.id,
+      title: b.title,
+      url: b.url,
+      sortOrder: index,
+      keywordIds: b.keywords.map((k) => k.id),
+    })
+  }
+}


### PR DESCRIPTION
Issue #486
肥大化した `extension/src/background.test.ts` を、メンテナンス性と可読性向上のため、機能（ドメイン）ごとに分割・整理しました。

## 変更内容
- `extension/src/background.test.utils.ts`: DBへのデータ投入など、共通のテストヘルパーを抽出。
- 以下の 3 ファイルに分割:
    - `background.icon.test.ts`: アイコン更新ロジック。
    - `background.bookmark.test.ts`: ブックマーク操作（READ_BOOKMARK_STATUS, READ_BOOKMARKS, CREATE_BOOKMARK, DELETE_BOOKMARK, UPDATE_BOOKMARK）。
    - `background.keyword.test.ts`: キーワード操作（未実装アクションのガード検証を含む）。
- 元の `background.test.ts` を削除。

これにより、アクション追加時のテストコード記述が容易になり、全体の構造が把握しやすくなりました。