### PR TITLE
[Extension] READ_KEYWORDS ハンドラの実装

### DIFF
--- a/extension/src/background.keyword.test.ts
+++ b/extension/src/background.keyword.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import 'fake-indexeddb/auto'
 
 import { API_ACTIONS, ERROR_CODES, LOG_MESSAGES } from '@shared/constants'
-import { MOCK_IDS, TEST_STRINGS } from '@shared/test/fixtures'
+import { MOCK_IDS, MOCK_KEYWORDS, TEST_STRINGS } from '@shared/test/fixtures'
+
+import { loadKeywords } from './background.test.utils'
 
 describe('background service worker', () => {
   beforeEach(() => {
@@ -41,12 +43,38 @@ describe('background service worker', () => {
     vi.resetModules()
   })
 
+  describe('統合メッセージディスパッチャ (READ_KEYWORDS)', () => {
+    it('READ_KEYWORDS アクションを受信した際に、全ブックマークを返すこと', async () => {
+      await loadKeywords(MOCK_KEYWORDS)
+
+      const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
+      await import('./background')
+
+      const messageHandler = addListenerMock.mock.calls[0][0]
+      const sendResponse = vi.fn()
+
+      const message = {
+        action: API_ACTIONS.READ_KEYWORDS,
+      }
+
+      const result = messageHandler(message, {}, sendResponse)
+      expect(result).toBe(true)
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: true,
+            data: {
+              keywords: expect.arrayContaining(MOCK_KEYWORDS),
+            },
+          }),
+        )
+      })
+    })
+  })
+
   describe('未実装のメッセージ', () => {
     it.each([
-      {
-        action: API_ACTIONS.READ_KEYWORDS,
-        payload: undefined,
-      },
       {
         action: API_ACTIONS.CREATE_KEYWORD,
         payload: { name: TEST_STRINGS.NEW_NAME },

--- a/extension/src/background.keyword.test.ts
+++ b/extension/src/background.keyword.test.ts
@@ -44,7 +44,7 @@ describe('background service worker', () => {
   })
 
   describe('統合メッセージディスパッチャ (READ_KEYWORDS)', () => {
-    it('READ_KEYWORDS アクションを受信した際に、全ブックマークを返すこと', async () => {
+    it('READ_KEYWORDS アクションを受信した際に、全キーワードを返すこと', async () => {
       await loadKeywords(MOCK_KEYWORDS)
 
       const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)

--- a/extension/src/background.test.utils.ts
+++ b/extension/src/background.test.utils.ts
@@ -1,4 +1,4 @@
-import type { Bookmark } from '@shared/schemas/bookmark'
+import type { Bookmark, Keyword } from '@shared/schemas/bookmark'
 
 import { db } from './lib/idb'
 
@@ -15,5 +15,13 @@ export const loadBookmarks = async (bookmarks: Bookmark[]) => {
       sortOrder: index,
       keywordIds: b.keywords.map((k) => k.id),
     })
+  }
+}
+
+export const loadKeywords = async (keywords: Keyword[]) => {
+  await db.keywords.clear()
+
+  for (const k of keywords) {
+    await db.keywords.add({ id: k.id, name: k.name, bookmarkCount: 0 })
   }
 }

--- a/extension/src/background.test.utils.ts
+++ b/extension/src/background.test.utils.ts
@@ -1,4 +1,4 @@
-import type { Bookmark } from '@shared/schemas/bookmark'
+import type { Bookmark, Keyword } from '@shared/schemas/bookmark'
 
 import { db } from './lib/idb'
 
@@ -16,4 +16,9 @@ export const loadBookmarks = async (bookmarks: Bookmark[]) => {
       keywordIds: b.keywords.map((k) => k.id),
     })
   }
+}
+
+export const loadKeywords = async (keywords: Keyword[]) => {
+  await db.keywords.clear()
+  await db.keywords.bulkAdd(keywords.map((k) => ({ ...k, bookmarkCount: 0 })))
 }

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -210,11 +210,20 @@ const handleApiMessage = async (
           throw err // 予期せぬエラーは上位で 500 として処理
         }
       }
+      case API_ACTIONS.READ_KEYWORDS: {
+        const keywords = await db.getAllKeywords()
+        return {
+          success: true,
+          data: {
+            keywords,
+          },
+        }
+      }
+
       case API_ACTIONS.REORDER_BOOKMARKS:
 
       // キーワード操作
       // eslint-disable-next-line no-fallthrough
-      case API_ACTIONS.READ_KEYWORDS:
       case API_ACTIONS.CREATE_KEYWORD:
       case API_ACTIONS.UPDATE_KEYWORD:
       case API_ACTIONS.DELETE_KEYWORD:


### PR DESCRIPTION
Issue #485
統合メッセージディスパッチャにおいて `READ_KEYWORDS` アクションをサポートし、IndexedDB に保存されているキーワード一覧（ブックマーク数カウントを含む）を返送するハンドラを実装しました。

## 変更内容
- `extension/src/background.ts`:
    - `handleApiMessage` 内に `READ_KEYWORDS` 分岐を追加し、`db.getAllKeywords()` を接続。
- `extension/src/background.test.utils.ts`:
    - キーワード投入用の `loadKeywords` ヘルパーを追加。非同期制御のため `for...of` を採用。
- `extension/src/background.keyword.test.ts`:
    - `READ_KEYWORDS` アクションの正常系テストケースを追加し、未実装リストから削除。

これにより、Web アプリ側からキーワード一覧をローカルデータとして取得できるようになりました。