### PR TITLE
[Extension] UPDATE_BOOKMARK ハンドラのキーワード結合対応

### DIFF
--- a/extension/src/background.bookmark.test.ts
+++ b/extension/src/background.bookmark.test.ts
@@ -15,10 +15,11 @@ import {
   MOCK_BOOKMARK_2,
   MOCK_BOOKMARK_3,
   MOCK_BOOKMARK_ENTITY_1,
+  MOCK_KEYWORDS,
   TEST_STRINGS,
 } from '@shared/test/fixtures'
 
-import { loadBookmarks } from './background.test.utils'
+import { loadBookmarks, loadKeywords } from './background.test.utils'
 import { db } from './lib/idb'
 
 describe('background service worker', () => {
@@ -461,6 +462,39 @@ describe('background service worker', () => {
 
         expect(await db.bookmarks.count()).toBe(1)
         expect(await db.bookmarks.get(MOCK_BOOKMARK_1.id)).toEqual(expected)
+      })
+
+      it('キーワードが紐付いたブックマークを更新した際、キーワード情報が維持されること', async () => {
+        await loadKeywords([MOCK_KEYWORDS[0]])
+        await loadBookmarks([
+          { ...MOCK_BOOKMARK_ENTITY_1, keywords: [MOCK_KEYWORDS[0]] },
+        ])
+
+        await import('./background')
+        const sendResponse = vi.fn()
+
+        vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+          {
+            action: API_ACTIONS.UPDATE_BOOKMARK,
+            payload: { id: MOCK_BOOKMARK_1.id, title: TEST_STRINGS.NEW_NAME },
+          },
+          {},
+          sendResponse,
+        )
+
+        await vi.waitFor(() => {
+          expect(sendResponse).toHaveBeenCalledWith(
+            expect.objectContaining({
+              success: true,
+              data: expect.objectContaining({
+                title: TEST_STRINGS.NEW_NAME,
+                keywords: expect.arrayContaining([
+                  expect.objectContaining({ name: MOCK_KEYWORDS[0].name }),
+                ]),
+              }),
+            }),
+          )
+        })
       })
     })
 

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -176,22 +176,17 @@ const handleApiMessage = async (
         const { id, ...params } = request.payload
 
         try {
-          // 2. 更新処理の実行
           await db.updateBookmark(id, params)
 
-          // 3. 更新後の最新データを取得
-          const updatedBookmark = await db.bookmarks.get(id)
+          const updatedBookmark = await db.getBookmarkWithKeywords(id)
+
           if (!updatedBookmark) {
             throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
           }
 
-          // 4. キーワード情報を付加して返送 (現在は空配列でOK)
           return {
             success: true,
-            data: {
-              ...updatedBookmark,
-              keywords: [],
-            },
+            data: updatedBookmark,
           }
         } catch (err: unknown) {
           // 重複エラー（URL更新時）やその他のエラーハンドリング

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -71,6 +71,24 @@ export class BookmarkDatabase extends Dexie {
   }
 
   /**
+   * 指定された ID のブックマークを、キーワード詳細を含めて取得する
+   */
+  async getBookmarkWithKeywords(id: BookmarkId): Promise<Bookmark | undefined> {
+    const entity = await this.bookmarks.get(id)
+    if (!entity) return undefined
+
+    const keywords = await this.keywords.bulkGet(entity.keywordIds)
+    const joinedKeywords = keywords.filter(
+      (k): k is KeywordWithCount => k !== undefined,
+    )
+
+    return {
+      ...entity,
+      keywords: joinedKeywords,
+    }
+  }
+
+  /**
    * ブックマークを作成する
    */
   async createBookmark(params: CreateBookmarkInput): Promise<BookmarkId> {


### PR DESCRIPTION
Issue #489
ブックマーク更新後のレスポンスに、既に紐付いているキーワード詳細を含めるように改善しました。これにより、更新直後にフロントエンド側でキーワード表示が一時的に消失する不整合が解消されます。

## 変更内容
- `extension/src/background.ts`:
    - `UPDATE_BOOKMARK` ハンドラにおいて、`db.keywords.bulkGet` を用いてキーワード情報を結合するロジックを実装。
- `extension/src/background.bookmark.test.ts`:
    - キーワードが紐付いたブックマークを更新した際、レスポンスに正しいキーワード詳細が含まれていることを検証するテストを追加。

本修正により、IndexedDB 内部の Entity 構造と、フロントエンドが期待する Bookmark オブジェクト構造の橋渡しがより正確になりました。