### PR TITLE
[Extension] CREATE_KEYWORD ハンドラの実装

### DIFF
--- a/extension/src/background.keyword.test.ts
+++ b/extension/src/background.keyword.test.ts
@@ -6,6 +6,7 @@ import { API_ACTIONS, ERROR_CODES, LOG_MESSAGES } from '@shared/constants'
 import { MOCK_IDS, MOCK_KEYWORDS, TEST_STRINGS } from '@shared/test/fixtures'
 
 import { loadKeywords } from './background.test.utils'
+import { db } from './lib/idb'
 
 describe('background service worker', () => {
   beforeEach(() => {
@@ -73,12 +74,98 @@ describe('background service worker', () => {
     })
   })
 
-  describe('未実装のメッセージ', () => {
+  describe('統合メッセージディスパッチャ (CREATE_KEYWORD)', () => {
+    beforeEach(async () => {
+      await loadKeywords([MOCK_KEYWORDS[0]])
+      await import('./background')
+    })
     it.each([
       {
-        action: API_ACTIONS.CREATE_KEYWORD,
-        payload: { name: TEST_STRINGS.NEW_NAME },
+        testName: '新しいキーワード',
+        keywordName: TEST_STRINGS.NEW_NAME,
+        count: 2,
       },
+      {
+        testName: '登録済みのキーワード',
+        keywordName: MOCK_KEYWORDS[0].name,
+        count: 1,
+      },
+    ])('正常終了: $testName', async ({ keywordName, count }) => {
+      const sendResponse = vi.fn()
+
+      vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+        {
+          action: API_ACTIONS.CREATE_KEYWORD,
+          payload: {
+            name: keywordName,
+          },
+        },
+        {},
+        sendResponse,
+      )
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: true,
+            data: {
+              keyword: expect.objectContaining({
+                name: keywordName,
+                id: expect.any(String),
+              }),
+            },
+          }),
+        )
+      })
+
+      // DB に実際に増えているかも確認
+      expect(await db.keywords.count()).toBe(count)
+
+      expect(
+        (await db.keywords.get(sendResponse.mock.calls[0][0].data.keyword.id))
+          ?.name,
+      ).toBe(keywordName)
+    })
+
+    it.each([
+      { testName: 'name欠落', payload: {} },
+      { testName: 'nameが空文字', payload: { name: '' } },
+      { testName: 'nameが長すぎ', payload: { name: '0'.repeat(100) } },
+    ])('異常終了: $testName', async (payload) => {
+      const sendResponse = vi.fn()
+
+      vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+        {
+          action: API_ACTIONS.CREATE_KEYWORD,
+          payload,
+        },
+        {},
+        sendResponse,
+      )
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: {
+              code: ERROR_CODES.BAD_REQUEST,
+              message: expect.stringContaining(
+                LOG_MESSAGES.INVALID_PAYLOAD(''),
+              ),
+            },
+          }),
+        )
+      })
+
+      expect(await db.keywords.count()).toBe(1)
+      expect(await db.keywords.get(MOCK_KEYWORDS[0].id)).toEqual(
+        MOCK_KEYWORDS[0],
+      )
+    })
+  })
+
+  describe('未実装のメッセージ', () => {
+    it.each([
       {
         action: API_ACTIONS.UPDATE_KEYWORD,
         payload: { name: TEST_STRINGS.NEW_NAME, id: MOCK_IDS.KEYWORD_1 },

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -215,11 +215,29 @@ const handleApiMessage = async (
         }
       }
 
+      case API_ACTIONS.CREATE_KEYWORD: {
+        const keyword = await db.keywords.get(
+          await db.createKeyword(request.payload),
+        )
+        if (!keyword) {
+          throw new Error(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+        }
+
+        return {
+          success: true,
+          data: {
+            keyword: {
+              id: keyword.id,
+              name: keyword.name,
+            },
+          },
+        }
+      }
+
       case API_ACTIONS.REORDER_BOOKMARKS:
 
       // キーワード操作
       // eslint-disable-next-line no-fallthrough
-      case API_ACTIONS.CREATE_KEYWORD:
       case API_ACTIONS.UPDATE_KEYWORD:
       case API_ACTIONS.DELETE_KEYWORD:
       // リレーション操作


### PR DESCRIPTION
Issue #491
統合メッセージディスパッチャにおいて `CREATE_KEYWORD` アクションをサポートし、IndexedDB にキーワードを保存するハンドラを実装しました。

## 変更内容
- `extension/src/background.ts`:
    - `handleApiMessage` 内に `CREATE_KEYWORD` ハンドラを実装。
    - `db.createKeyword()` を呼び出し、作成（または既存取得）されたデータを返送。
- `extension/src/background.keyword.test.ts`:
    - 正常系（新規作成、既存キーワードの再利用）のテスト。
    - 異常系（名前の欠落、空文字、長すぎ）の境界値テスト。
    - レスポンスから動的に ID を取得して DB の実体を検証する高度なアサーションの実装。

これにより、フロントエンドからメッセージを介してローカルのキーワードを安全に作成・管理できるようになりました。