### PR TITLE
[Extension] DELETE_KEYWORD ハンドラの実装

### DIFF
--- a/extension/src/background.keyword.test.ts
+++ b/extension/src/background.keyword.test.ts
@@ -164,15 +164,93 @@ describe('background service worker', () => {
     })
   })
 
+  describe('統合メッセージディスパッチャ (DELETE_KEYWORD)', () => {
+    beforeEach(async () => {
+      await loadKeywords([MOCK_KEYWORDS[0]])
+    })
+    it.each([
+      {
+        testName: '登録されているidを指定',
+        id: MOCK_KEYWORDS[0].id,
+        count: 0,
+        getResult: undefined,
+      },
+      {
+        testName: '未登録のidを指定',
+        id: MOCK_IDS.UNKNOWN_ID,
+        count: 1,
+        getResult: MOCK_KEYWORDS[0],
+      },
+    ])('正常終了: $testName', async ({ id, count, getResult }) => {
+      await import('./background')
+
+      const sendResponse = vi.fn()
+
+      vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+        {
+          action: API_ACTIONS.DELETE_KEYWORD,
+          payload: { id },
+        },
+        {},
+        sendResponse,
+      )
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: true,
+            data: null,
+          }),
+        )
+      })
+
+      expect(await db.keywords.count()).toBe(count)
+      expect(await db.keywords.get(MOCK_KEYWORDS[0].id)).toEqual(getResult)
+    })
+
+    it.each([
+      { testName: 'IDなし', payload: {} },
+      { testName: 'IDが不正', payload: { id: TEST_STRINGS.INVALID_ID } },
+    ])('異常終了: $testName', async ({ payload }) => {
+      await import('./background')
+
+      const sendResponse = vi.fn()
+
+      vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+        {
+          action: API_ACTIONS.DELETE_KEYWORD,
+          payload,
+        },
+        {},
+        sendResponse,
+      )
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: {
+              code: ERROR_CODES.BAD_REQUEST,
+              message: expect.stringContaining(
+                LOG_MESSAGES.INVALID_PAYLOAD(''),
+              ),
+            },
+          }),
+        )
+      })
+
+      expect(await db.keywords.count()).toBe(1)
+      expect(await db.keywords.get(MOCK_KEYWORDS[0].id)).toEqual(
+        MOCK_KEYWORDS[0],
+      )
+    })
+  })
+
   describe('未実装のメッセージ', () => {
     it.each([
       {
         action: API_ACTIONS.UPDATE_KEYWORD,
         payload: { name: TEST_STRINGS.NEW_NAME, id: MOCK_IDS.KEYWORD_1 },
-      },
-      {
-        action: API_ACTIONS.DELETE_KEYWORD,
-        payload: { id: MOCK_IDS.KEYWORD_1 },
       },
       {
         action: API_ACTIONS.ATTACH_KEYWORD,

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -234,12 +234,21 @@ const handleApiMessage = async (
         }
       }
 
+      case API_ACTIONS.DELETE_KEYWORD: {
+        // 冗長なバリデーションは不要なので、直接 payload を使います
+        await db.deleteKeyword(request.payload.id)
+
+        return {
+          success: true,
+          data: null, // 削除成功時はデータなし
+        }
+      }
+
       case API_ACTIONS.REORDER_BOOKMARKS:
 
       // キーワード操作
       // eslint-disable-next-line no-fallthrough
       case API_ACTIONS.UPDATE_KEYWORD:
-      case API_ACTIONS.DELETE_KEYWORD:
       // リレーション操作
       // eslint-disable-next-line no-fallthrough
       case API_ACTIONS.ATTACH_KEYWORD:

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -368,7 +368,7 @@ export class BookmarkDatabase extends Dexie {
         // 存在確認
         const existing = await this.keywords.get(validatedId)
         if (!existing) {
-          throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+          return
         }
 
         // キーワード自体を削除

--- a/extension/src/lib/keyword-idb.test.ts
+++ b/extension/src/lib/keyword-idb.test.ts
@@ -147,11 +147,12 @@ describe('BookmarkDatabase - Keyword Operations', () => {
       expect(updatedBookmark?.keywordIds).toHaveLength(0)
     })
 
-    it('存在しない ID の削除を試みた場合にエラーを投げること', async () => {
-      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
-      await expect(db.deleteKeyword(unknownId)).rejects.toThrow(
-        ERROR_MESSAGES.KEYWORD_NOT_FOUND,
-      )
+    it('存在しない ID の削除を試みた場合になにも起きないこと', async () => {
+      await db.keywords.add(MOCK_KEYWORDS[0])
+
+      await db.deleteKeyword(MOCK_KEYWORDS[1].id)
+      const keyword = await db.keywords.get(MOCK_KEYWORDS[0].id)
+      expect(keyword).toEqual(MOCK_KEYWORDS[0])
     })
 
     it('不正な形式の ID での削除を試みた場合にバリデーションエラーを投げること', async () => {


### PR DESCRIPTION
Issue #493
統合メッセージディスパッチャにおいて `DELETE_KEYWORD` アクションをサポートし、IndexedDB からキーワードを削除するハンドラを実装しました。

## 変更内容
- `extension/src/background.ts`:
    - `handleApiMessage` 内に `DELETE_KEYWORD` ハンドラを実装。
- `extension/src/lib/idb.ts`:
    - `deleteKeyword` メソッドをリファクタリングし、存在しない ID に対しても例外を投げず正常終了する「冪等（べきとう）」な設計に変更。
- `extension/src/background.keyword.test.ts`:
    - 正常系（登録済み・未登録ID）および異常系（バリデーションエラー）のテストを追加。
    - 不正なリクエストによって既存データが破壊されないことを検証。
- `extension/src/lib/keyword-idb.test.ts`:
    - 冪等性の確保に伴うテスト期待値の修正。

これにより、フロントエンドからメッセージを介してローカルのキーワードを安全かつ確実に削除できるようになりました。