### PR TITLE
[Shared] バリデーション制限値の定数化

### DIFF
--- a/extension/src/background.keyword.test.ts
+++ b/extension/src/background.keyword.test.ts
@@ -7,6 +7,7 @@ import {
   ERROR_CODES,
   ERROR_MESSAGES,
   LOG_MESSAGES,
+  VALIDATION_LIMITS,
 } from '@shared/constants'
 import { MOCK_IDS, MOCK_KEYWORDS, TEST_STRINGS } from '@shared/test/fixtures'
 
@@ -135,7 +136,12 @@ describe('background service worker', () => {
     it.each([
       { testName: 'name欠落', payload: {} },
       { testName: 'nameが空文字', payload: { name: '' } },
-      { testName: 'nameが長すぎ', payload: { name: '0'.repeat(100) } },
+      {
+        testName: 'nameが長すぎ',
+        payload: {
+          name: '0'.repeat(VALIDATION_LIMITS.KEYWORD_NAME_MAX_LENGTH + 1),
+        },
+      },
     ])('異常終了: $testName', async (payload) => {
       const sendResponse = vi.fn()
 
@@ -357,7 +363,7 @@ describe('background service worker', () => {
         testName: '名前が長すぎ',
         payload: {
           id: MOCK_KEYWORDS[0].id,
-          name: '0'.repeat(100),
+          name: '0'.repeat(VALIDATION_LIMITS.KEYWORD_NAME_MAX_LENGTH + 1),
         },
         error: {
           code: ERROR_CODES.BAD_REQUEST,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -56,6 +56,13 @@ export const DEFAULT_API_URL = `http://localhost:${DEFAULT_PORTS.BACKEND}`
 export const DEFAULT_FRONTEND_URL = `http://localhost:${DEFAULT_PORTS.FRONTEND}`
 export const DEFAULT_SERVER_PORT = DEFAULT_PORTS.BACKEND
 
+export const VALIDATION_LIMITS = {
+  BOOKMARK_TITLE_MIN_LENGTH: 1,
+  REORDER_MAX_ITEMS: 1000,
+  KEYWORD_NAME_MIN_LENGTH: 1,
+  KEYWORD_NAME_MAX_LENGTH: 50,
+} as const
+
 /**
  * UI の処理状態定義
  */
@@ -446,12 +453,12 @@ export const VALIDATION_MESSAGES = {
   TITLE_REQUIRED: 'タイトルは必須です',
   TITLE_MIN_LENGTH: 'タイトルは1文字以上である必要があります',
   KEYWORD_MIN_LENGTH: 'キーワード名は1文字以上である必要があります',
-  KEYWORD_MAX_LENGTH: 'キーワード名は50文字以内で入力してください',
+  KEYWORD_MAX_LENGTH: `キーワード名は${VALIDATION_LIMITS.KEYWORD_NAME_MAX_LENGTH}文字以内で入力してください`,
   URL_INVALID_PROTOCOL: 'URL は http:// または https:// で始まる必要があります',
   URL_INVALID_FORMAT: '有効な URL形式である必要があります',
   UPDATE_MIN_FIELDS:
     'タイトルまたは URL の少なくとも一方は指定する必要があります',
-  REORDER_MAX_ITEMS: '一度に並び替えられるのは1000件までです',
+  REORDER_MAX_ITEMS: `一度に並び替えられるのは${VALIDATION_LIMITS.REORDER_MAX_ITEMS}件までです`,
   REORDER_DUPLICATE_IDS: 'IDリストに重複が含まれています',
   BOOKMARK_STATUS_REQUIRED_BOOKMARKID:
     '登録済み、変更ありの場合にはBOOKMARK IDが必要です',

--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -6,6 +6,7 @@ import {
   ERROR_MESSAGES,
   ERROR_CODES,
   BOOKMARK_STATUS,
+  VALIDATION_LIMITS,
 } from '../constants'
 import {
   readBookmarksRequestSchema,
@@ -317,9 +318,10 @@ describe('API Schemas - Bookmark Operations', () => {
       )
     })
 
-    it('1000件を超える ID リストを拒否すること', () => {
-      const manyIds = Array.from({ length: 1001 }, (_, i) =>
-        generateMockUuidV7(i),
+    it(`${VALIDATION_LIMITS.REORDER_MAX_ITEMS}件を超える ID リストを拒否すること`, () => {
+      const manyIds = Array.from(
+        { length: VALIDATION_LIMITS.REORDER_MAX_ITEMS + 1 },
+        (_, i) => generateMockUuidV7(i),
       )
       const invalidRequest = {
         action: API_ACTIONS.REORDER_BOOKMARKS,

--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -10,7 +10,11 @@ import {
   reorderBookmarksInputSchema,
   updateBookmarkInputSchema,
 } from './bookmark'
-import { BOOKMARK_STATUS, VALIDATION_MESSAGES } from '../constants'
+import {
+  BOOKMARK_STATUS,
+  VALIDATION_LIMITS,
+  VALIDATION_MESSAGES,
+} from '../constants'
 import {
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_TITLE_PREFIX,
@@ -129,8 +133,9 @@ describe('reorderBookmarksInputSchema', () => {
 
   it('上限を超える ID リストを拒否すること', () => {
     // 1001個の有効な UUID v7 を生成
-    const manyIds = Array.from({ length: 1001 }, (_, i) =>
-      generateMockUuidV7(i),
+    const manyIds = Array.from(
+      { length: VALIDATION_LIMITS.REORDER_MAX_ITEMS + 1 },
+      (_, i) => generateMockUuidV7(i),
     )
     const result = reorderBookmarksInputSchema.safeParse({ ids: manyIds })
     expect(result.success).toBe(false)

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 
-import { BOOKMARK_STATUS, VALIDATION_MESSAGES } from '../constants'
+import {
+  BOOKMARK_STATUS,
+  VALIDATION_LIMITS,
+  VALIDATION_MESSAGES,
+} from '../constants'
 import { keywordSchema, KeywordIdSchema } from './keyword'
 import { isHttpUrl } from '../utils/url'
 
@@ -20,7 +24,10 @@ export type BookmarkId = z.infer<typeof BookmarkIdSchema>
 const bookmarkTitleSchema = z
   .string()
   .trim()
-  .min(1, VALIDATION_MESSAGES.TITLE_REQUIRED)
+  .min(
+    VALIDATION_LIMITS.BOOKMARK_TITLE_MIN_LENGTH,
+    VALIDATION_MESSAGES.TITLE_REQUIRED,
+  )
 
 /**
  * ブックマークURLの共通バリデーションスキーマ
@@ -85,7 +92,10 @@ export type DeleteBookmarkInput = z.infer<typeof deleteBookmarkInputSchema>
 export const reorderBookmarksInputSchema = z.object({
   ids: z
     .array(BookmarkIdSchema)
-    .max(1000, VALIDATION_MESSAGES.REORDER_MAX_ITEMS)
+    .max(
+      VALIDATION_LIMITS.REORDER_MAX_ITEMS,
+      VALIDATION_MESSAGES.REORDER_MAX_ITEMS,
+    )
     .refine((ids) => new Set(ids).size === ids.length, {
       message: VALIDATION_MESSAGES.REORDER_DUPLICATE_IDS,
     }),

--- a/shared/schemas/keyword.test.ts
+++ b/shared/schemas/keyword.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
+import { VALIDATION_LIMITS } from '@shared/constants'
+
 import {
   KeywordIdSchema,
   keywordSchema,
@@ -88,9 +90,11 @@ describe('Keyword Schemas', () => {
       expect(() => updateKeywordInputSchema.parse({ name: '' })).toThrow()
     })
 
-    it('名前が50文字を超える場合にエラーになること', () => {
+    it(`名前が${VALIDATION_LIMITS.KEYWORD_NAME_MAX_LENGTH}文字を超える場合にエラーになること`, () => {
       expect(() =>
-        updateKeywordInputSchema.parse({ name: 'a'.repeat(51) }),
+        updateKeywordInputSchema.parse({
+          name: 'a'.repeat(VALIDATION_LIMITS.KEYWORD_NAME_MAX_LENGTH + 1),
+        }),
       ).toThrow()
     })
   })

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { VALIDATION_MESSAGES } from '@shared/constants'
+import { VALIDATION_LIMITS, VALIDATION_MESSAGES } from '@shared/constants'
 
 export const KeywordIdSchema = z.string().uuid().brand<'KeywordId'>()
 export type KeywordId = z.infer<typeof KeywordIdSchema>
@@ -11,8 +11,14 @@ export type KeywordId = z.infer<typeof KeywordIdSchema>
 const keywordNameSchema = z
   .string()
   .trim()
-  .min(1, VALIDATION_MESSAGES.KEYWORD_MIN_LENGTH)
-  .max(50, VALIDATION_MESSAGES.KEYWORD_MAX_LENGTH)
+  .min(
+    VALIDATION_LIMITS.KEYWORD_NAME_MIN_LENGTH,
+    VALIDATION_MESSAGES.KEYWORD_MIN_LENGTH,
+  )
+  .max(
+    VALIDATION_LIMITS.KEYWORD_NAME_MAX_LENGTH,
+    VALIDATION_MESSAGES.KEYWORD_MAX_LENGTH,
+  )
 
 export const keywordSchema = z.object({
   id: KeywordIdSchema,


### PR DESCRIPTION
Issue #498
コード内に直接記述されていたバリデーション制限値（1000件、50文字など）を定数化し、一元管理できるようにしました。

## 変更内容
- `shared/constants.ts`: `VALIDATION_LIMITS` 定数を新設。
- `shared/schemas/`: ブックマーク並べ替え上限数、キーワード名最大長の指定を定数参照に変更。
- 各種テストコード: 境界値テストの数値を定数ベースの動的な記述に変更。
- エラーメッセージ: 制限値を含むメッセージをテンプレートリテラル化。

これにより、将来的な制限値の変更に対する保守性が向上しました。