### PR TITLE
[Extension] ATTACH_KEYWORD ハンドラの実装

### DIFF
--- a/extension/src/background.keyword.test.ts
+++ b/extension/src/background.keyword.test.ts
@@ -9,9 +9,14 @@ import {
   LOG_MESSAGES,
   VALIDATION_LIMITS,
 } from '@shared/constants'
-import { MOCK_IDS, MOCK_KEYWORDS, TEST_STRINGS } from '@shared/test/fixtures'
+import {
+  MOCK_BOOKMARKS,
+  MOCK_IDS,
+  MOCK_KEYWORDS,
+  TEST_STRINGS,
+} from '@shared/test/fixtures'
 
-import { loadKeywords } from './background.test.utils'
+import { loadBookmarks, loadKeywords } from './background.test.utils'
 import { db } from './lib/idb'
 
 describe('background service worker', () => {
@@ -400,15 +405,149 @@ describe('background service worker', () => {
     })
   })
 
-  describe('未実装のメッセージ', () => {
+  describe('統合メッセージディスパッチャ (ATTACH_KEYWORD)', () => {
+    const bookmark = MOCK_BOOKMARKS[0]
+    const keyword = MOCK_KEYWORDS[0]
+    beforeEach(async () => {
+      await loadKeywords([keyword])
+      await loadBookmarks([bookmark])
+    })
+
     it.each([
+      { testName: '紐付け', setup: async () => {} },
       {
-        action: API_ACTIONS.ATTACH_KEYWORD,
-        payload: {
-          keywordId: MOCK_IDS.KEYWORD_1,
-          bookmarkId: MOCK_IDS.BOOKMARK_1,
+        testName: '既に紐付け済み',
+        setup: async () => {
+          await db.attachKeyword(bookmark.id, keyword.id)
         },
       },
+    ])('$testName', async ({ setup }) => {
+      await import('./background')
+      const sendResponse = vi.fn()
+      await setup()
+
+      vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+        {
+          action: API_ACTIONS.ATTACH_KEYWORD,
+          payload: {
+            bookmarkId: bookmark.id,
+            keywordId: keyword.id,
+          },
+        },
+        {},
+        sendResponse,
+      )
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: true,
+            data: expect.objectContaining({
+              // ✅ null から変更
+              id: bookmark.id,
+              keywords: expect.arrayContaining([
+                expect.objectContaining({ id: keyword.id }),
+              ]),
+            }),
+          }),
+        )
+      })
+
+      // DB の実体を確認 (ブックマークにキーワード ID が含まれていること)
+      const updatedBookmark = await db.bookmarks.get(bookmark.id)
+      expect(updatedBookmark?.keywordIds).toContain(keyword.id)
+    })
+
+    it.each([
+      {
+        testName: 'IDともになし',
+        payload: {},
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: 'bookmark idなし',
+        payload: { keywordId: keyword.id },
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: 'bookmark idが不正な形式',
+        payload: { bookmarkId: TEST_STRINGS.INVALID_ID, keywordId: keyword.id },
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: 'keyword idなし',
+        payload: { bookmarkId: bookmark.id },
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: 'keyword idが不正な形式',
+        payload: {
+          bookmarkId: bookmark.id,
+          keywordId: TEST_STRINGS.INVALID_ID,
+        },
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: '未登録のbookmark idを指定',
+        payload: { bookmarkId: MOCK_IDS.UNKNOWN_ID, keywordId: keyword.id },
+        error: {
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          message: expect.stringContaining(ERROR_MESSAGES.BOOKMARK_NOT_FOUND),
+        },
+      },
+      {
+        testName: '未登録のkeyword idを指定',
+        payload: { bookmarkId: bookmark.id, keywordId: MOCK_IDS.UNKNOWN_ID },
+        error: {
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          message: expect.stringContaining(ERROR_MESSAGES.KEYWORD_NOT_FOUND),
+        },
+      },
+    ])('異常終了: $testName', async ({ payload, error }) => {
+      await import('./background')
+
+      const sendResponse = vi.fn()
+
+      vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+        {
+          action: API_ACTIONS.ATTACH_KEYWORD,
+          payload,
+        },
+        {},
+        sendResponse,
+      )
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error,
+          }),
+        )
+      })
+
+      const updatedBookmark = await db.bookmarks.get(bookmark.id)
+      expect(updatedBookmark?.keywordIds).not.toContain(keyword.id)
+    })
+  })
+
+  describe('未実装のメッセージ', () => {
+    it.each([
       {
         action: API_ACTIONS.DETACH_KEYWORD,
         payload: {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -296,7 +296,27 @@ const handleApiMessage = async (
       }
 
       // リレーション操作
-      case API_ACTIONS.ATTACH_KEYWORD:
+      case API_ACTIONS.ATTACH_KEYWORD: {
+        // 1. request.payload から各 ID を取り出す
+        const { bookmarkId, keywordId } = request.payload
+
+        // 2. 紐付け処理の実行
+        await db.attachKeyword(bookmarkId, keywordId)
+
+        // 3. 更新後の最新データを取得（共通メソッドを利用）
+        const updatedBookmark = await db.getBookmarkWithKeywords(bookmarkId)
+
+        if (!updatedBookmark) {
+          throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+        }
+
+        // 3. 成功レスポンス（更新後のブックマークを返す）
+        return {
+          success: true,
+          data: updatedBookmark,
+        }
+      }
+
       case API_ACTIONS.DETACH_KEYWORD:
         // 今回の Issue では「未実装エラー」を返すプレースホルダのみ
         // 実際の接続は今後の個別 Issue で実施

--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -16,7 +16,12 @@ import {
   detachKeywordRequestSchema,
   detachKeywordResponseSchema,
 } from './api'
-import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
+import {
+  MOCK_KEYWORDS,
+  MOCK_IDS,
+  TEST_STRINGS,
+  MOCK_BOOKMARK_1,
+} from '../test/fixtures'
 
 describe('API Schemas - Keyword Operations', () => {
   describe('readKeywordsRequestSchema', () => {
@@ -229,7 +234,7 @@ describe('API Schemas - Keyword Operations', () => {
 
   describe('attachKeywordResponseSchema', () => {
     it('成功時のレスポンスを検証できること', () => {
-      const validResponse = { success: true, data: null }
+      const validResponse = { success: true, data: MOCK_BOOKMARK_1 }
       expect(attachKeywordResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -169,9 +169,7 @@ export const attachKeywordRequestSchema = baseApiRequestSchema.extend({
 
 export type AttachKeywordRequest = z.infer<typeof attachKeywordRequestSchema>
 
-export const attachKeywordResponseSchema = baseApiResponseSchema(
-  z.null(), // 紐付け成功時はデータなし
-)
+export const attachKeywordResponseSchema = baseApiResponseSchema(bookmarkSchema)
 
 export type AttachKeywordResponse = z.infer<typeof attachKeywordResponseSchema>
 


### PR DESCRIPTION
Issue #503
統合メッセージディスパッチャにおいて `ATTACH_KEYWORD` アクションをサポートし、ブックマークとキーワードの紐付けを IndexedDB に永続化するハンドラを実装しました。

## 変更内容
- `extension/src/background.ts`:
    - `ATTACH_KEYWORD` ハンドラを実装し、`db.attachKeyword` を接続。
- `extension/src/background.keyword.test.ts`:
    - 正常系（新規紐付け、既に紐付け済みの場合の冪等性）のテストを追加。
    - 異常系（ID欠落、不正形式、未登録IDの指定等）の網羅的なテストを追加。

本修正により、フロントエンドからメッセージを介してブックマークへのキーワード割当が安全に行えるようになりました。