### PR TITLE
[Extension] DETACH_KEYWORD ハンドラの実装

### DIFF
--- a/extension/src/background.keyword.test.ts
+++ b/extension/src/background.keyword.test.ts
@@ -546,25 +546,137 @@ describe('background service worker', () => {
     })
   })
 
-  describe('未実装のメッセージ', () => {
+  describe('統合メッセージディスパッチャ (DETACH_KEYWORD)', () => {
+    beforeEach(async () => {
+      await loadBookmarks(MOCK_BOOKMARKS)
+      await loadKeywords(MOCK_KEYWORDS)
+      await db.attachKeyword(MOCK_BOOKMARKS[0].id, MOCK_KEYWORDS[0].id)
+    })
+
     it.each([
       {
-        action: API_ACTIONS.DETACH_KEYWORD,
-        payload: {
-          keywordId: MOCK_IDS.KEYWORD_1,
-          bookmarkId: MOCK_IDS.BOOKMARK_1,
-        },
+        testName: 'ブックマークからキーワードを解除',
+        bookmarkId: MOCK_BOOKMARKS[0].id,
+        keywordId: MOCK_KEYWORDS[0].id,
       },
-    ])('$action', async ({ action, payload }) => {
-      const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
+      {
+        testName: 'キーワードを割り当てていないブックマークを指定',
+        bookmarkId: MOCK_BOOKMARKS[1].id,
+        keywordId: MOCK_KEYWORDS[0].id,
+      },
+      {
+        testName: 'ブックマークに割り当てていないキーワードを指定',
+        bookmarkId: MOCK_BOOKMARKS[0].id,
+        keywordId: MOCK_KEYWORDS[1].id,
+      },
+    ])('$testName', async ({ bookmarkId, keywordId }) => {
       await import('./background')
-
-      const messageHandler = addListenerMock.mock.calls[0][0]
       const sendResponse = vi.fn()
 
-      messageHandler(
+      vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
         {
-          action,
+          action: API_ACTIONS.DETACH_KEYWORD,
+          payload: { bookmarkId, keywordId },
+        },
+        {},
+        sendResponse,
+      )
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: true,
+            data: expect.objectContaining({
+              id: bookmarkId,
+              keywords: expect.not.arrayContaining([
+                expect.objectContaining({ id: keywordId }),
+              ]),
+            }),
+          }),
+        )
+      })
+
+      expect((await db.bookmarks.get(bookmarkId))?.keywordIds).not.toContain(
+        keywordId,
+      )
+    })
+    it.each([
+      {
+        testName: 'IDともになし',
+        payload: {},
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: 'bookmark idなし',
+        payload: { keywordId: MOCK_KEYWORDS[0].id },
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: 'bookmark idが不正な形式',
+        payload: {
+          bookmarkId: TEST_STRINGS.INVALID_ID,
+          keywordId: MOCK_KEYWORDS[0].id,
+        },
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: 'keyword idなし',
+        payload: { bookmarkId: MOCK_BOOKMARKS[0].id },
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: 'keyword idが不正な形式',
+        payload: {
+          bookmarkId: MOCK_BOOKMARKS[0].id,
+          keywordId: TEST_STRINGS.INVALID_ID,
+        },
+        error: {
+          code: ERROR_CODES.BAD_REQUEST,
+          message: expect.stringContaining(LOG_MESSAGES.INVALID_PAYLOAD('')),
+        },
+      },
+      {
+        testName: '未登録のbookmark idを指定',
+        payload: {
+          bookmarkId: MOCK_IDS.UNKNOWN_ID,
+          keywordId: MOCK_KEYWORDS[0].id,
+        },
+        error: {
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          message: expect.stringContaining(ERROR_MESSAGES.BOOKMARK_NOT_FOUND),
+        },
+      },
+      {
+        testName: '未登録のkeyword idを指定',
+        payload: {
+          bookmarkId: MOCK_BOOKMARKS[0].id,
+          keywordId: MOCK_IDS.UNKNOWN_ID,
+        },
+        error: {
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          message: expect.stringContaining(ERROR_MESSAGES.KEYWORD_NOT_FOUND),
+        },
+      },
+    ])('異常終了: $testName', async ({ payload, error }) => {
+      await import('./background')
+
+      const sendResponse = vi.fn()
+
+      vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0][0](
+        {
+          action: API_ACTIONS.DETACH_KEYWORD,
           payload,
         },
         {},
@@ -575,13 +687,17 @@ describe('background service worker', () => {
         expect(sendResponse).toHaveBeenCalledWith(
           expect.objectContaining({
             success: false,
-            error: {
-              message: LOG_MESSAGES.ACTION_NOT_IMPLEMENTED(action),
-              code: ERROR_CODES.INTERNAL_SERVER_ERROR,
-            },
+            error,
           }),
         )
       })
+
+      expect(
+        (await db.bookmarks.get(MOCK_BOOKMARKS[0].id))?.keywordIds,
+      ).toContain(MOCK_KEYWORDS[0].id)
+      expect(
+        (await db.bookmarks.get(MOCK_BOOKMARKS[1].id))?.keywordIds,
+      ).not.toContain(MOCK_KEYWORDS[0].id)
     })
   })
 })

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -317,16 +317,26 @@ const handleApiMessage = async (
         }
       }
 
-      case API_ACTIONS.DETACH_KEYWORD:
-        // 今回の Issue では「未実装エラー」を返すプレースホルダのみ
-        // 実際の接続は今後の個別 Issue で実施
-        return {
-          success: false,
-          error: {
-            message: LOG_MESSAGES.ACTION_NOT_IMPLEMENTED(request.action),
-            code: ERROR_CODES.INTERNAL_SERVER_ERROR,
-          },
+      case API_ACTIONS.DETACH_KEYWORD: {
+        // 1. request.payload から各 ID を取り出す
+        const { bookmarkId, keywordId } = request.payload
+
+        // 2. 紐付け処理の実行
+        await db.detachKeyword(bookmarkId, keywordId)
+
+        // 3. 更新後の最新データを取得（共通メソッドを利用）
+        const updatedBookmark = await db.getBookmarkWithKeywords(bookmarkId)
+
+        if (!updatedBookmark) {
+          throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
         }
+
+        // 3. 成功レスポンス（更新後のブックマークを返す）
+        return {
+          success: true,
+          data: updatedBookmark,
+        }
+      }
 
       default:
         return {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -321,7 +321,7 @@ const handleApiMessage = async (
         // 1. request.payload から各 ID を取り出す
         const { bookmarkId, keywordId } = request.payload
 
-        // 2. 紐付け処理の実行
+        // 2. 紐付け解除処理の実行
         await db.detachKeyword(bookmarkId, keywordId)
 
         // 3. 更新後の最新データを取得（共通メソッドを利用）

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -331,7 +331,7 @@ const handleApiMessage = async (
           throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
         }
 
-        // 3. 成功レスポンス（更新後のブックマークを返す）
+        // 4. 成功レスポンス（更新後のブックマークを返す）
         return {
           success: true,
           data: updatedBookmark,

--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -296,7 +296,7 @@ describe('API Schemas - Keyword Operations', () => {
 
   describe('detachKeywordResponseSchema', () => {
     it('成功時のレスポンスを検証できること', () => {
-      const validResponse = { success: true, data: null }
+      const validResponse = { success: true, data: MOCK_BOOKMARK_1 }
       expect(detachKeywordResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -183,7 +183,7 @@ export const detachKeywordRequestSchema = baseApiRequestSchema.extend({
 
 export type DetachKeywordRequest = z.infer<typeof detachKeywordRequestSchema>
 
-export const detachKeywordResponseSchema = baseApiResponseSchema(z.null())
+export const detachKeywordResponseSchema = baseApiResponseSchema(bookmarkSchema)
 
 export type DetachKeywordResponse = z.infer<typeof detachKeywordResponseSchema>
 


### PR DESCRIPTION
Issue #505
統合メッセージディスパッチャにおいて `DETACH_KEYWORD` アクションをサポートし、ブックマークとキーワードの紐付けを解除するハンドラを実装しました。

## 変更内容
- `shared/schemas/api.ts`:
    - `detachKeywordResponseSchema` を修正し、成功時に更新後のブックマーク（キーワード詳細含む）を返すように変更。
- `extension/src/background.ts`:
    - `DETACH_KEYWORD` ハンドラを実装し、`db.detachKeyword` を接続。
    - 解除完了後に最新データを再取得して返却。
- `extension/src/background.keyword.test.ts`:
    - 正常系（解除成功）のテストを追加。
    - 冪等性（既に紐付いていない場合の安全な終了）の網羅的なテスト。
    - 異常系（バリデーションエラー、未登録ID等）の検証を追加。

本修正により、フロントエンドからメッセージを介してキーワード解除を安全かつ即座に行えるようになりました。