### PR TITLE
[Extension] reorderBookmarks における厳格な件数チェックの実装

### DIFF
--- a/extension/src/lib/bookmark-reorder-idb.test.ts
+++ b/extension/src/lib/bookmark-reorder-idb.test.ts
@@ -2,7 +2,7 @@ import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ZodError } from 'zod'
 
-import { ERROR_MESSAGES } from '@shared/constants'
+import { ERROR_MESSAGES, VALIDATION_MESSAGES } from '@shared/constants'
 import { type BookmarkId, BookmarkIdSchema } from '@shared/schemas/bookmark'
 import {
   MOCK_BOOKMARK_ENTITY_1,
@@ -29,7 +29,7 @@ describe('BookmarkDatabase - Bookmark Reorder Operations', () => {
 
       // 順序を入れ替える (b3, b1, b2)
       const newOrder = [b3.id, b1.id, b2.id]
-      
+
       await db.reorderBookmarks(newOrder)
 
       const result = await db.getAllBookmarks()
@@ -37,7 +37,7 @@ describe('BookmarkDatabase - Bookmark Reorder Operations', () => {
       expect(result[0].id).toBe(b3.id)
       expect(result[1].id).toBe(b1.id)
       expect(result[2].id).toBe(b2.id)
-      
+
       // sortOrder が連続した値 (0, 1, 2) に更新されていることを確認
       expect(result[0].sortOrder).toBe(0)
       expect(result[1].sortOrder).toBe(1)
@@ -45,17 +45,50 @@ describe('BookmarkDatabase - Bookmark Reorder Operations', () => {
     })
 
     it('重複した ID を含むリストを拒否すること (ZodError)', async () => {
-      const ids = [MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_1] as unknown as BookmarkId[]
+      const ids = [
+        MOCK_IDS.BOOKMARK_1,
+        MOCK_IDS.BOOKMARK_1,
+      ] as unknown as BookmarkId[]
       await expect(db.reorderBookmarks(ids)).rejects.toThrow(ZodError)
     })
 
     it('存在しない ID を含むリストを渡した場合にエラーを投げること', async () => {
-      await db.bookmarks.add(MOCK_BOOKMARK_ENTITY_1)
-      const ids = [MOCK_BOOKMARK_ENTITY_1.id, BookmarkIdSchema.parse(MOCK_IDS.UNKNOWN_ID)]
-      
+      await db.bookmarks.bulkAdd([
+        MOCK_BOOKMARK_ENTITY_1,
+        MOCK_BOOKMARK_ENTITY_2,
+      ])
+      const ids = [
+        MOCK_BOOKMARK_ENTITY_1.id,
+        BookmarkIdSchema.parse(MOCK_IDS.UNKNOWN_ID),
+      ]
+
       await expect(db.reorderBookmarks(ids)).rejects.toThrow(
         ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
       )
     })
+
+    it.each([
+      { testName: '少ない', ids: [MOCK_BOOKMARK_ENTITY_1.id] },
+      {
+        testName: '多い',
+        ids: [
+          MOCK_BOOKMARK_ENTITY_1.id,
+          MOCK_BOOKMARK_ENTITY_2.id,
+          MOCK_BOOKMARK_ENTITY_3.id,
+        ],
+      },
+    ])(
+      `DB内の総数より $testName 件数の ID リストが渡された場合にエラーを投げること`,
+      async ({ ids }) => {
+        await db.bookmarks.bulkAdd([
+          MOCK_BOOKMARK_ENTITY_1,
+          MOCK_BOOKMARK_ENTITY_2,
+        ])
+
+        await expect(db.reorderBookmarks(ids)).rejects.toThrow(
+          VALIDATION_MESSAGES.REORDER_COUNT_MISMATCH,
+        )
+      },
+    )
   })
 })

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -1,6 +1,10 @@
 import Dexie, { type Table } from 'dexie'
 
-import { DB_CONSTANTS, ERROR_MESSAGES } from '@shared/constants'
+import {
+  DB_CONSTANTS,
+  ERROR_MESSAGES,
+  VALIDATION_MESSAGES,
+} from '@shared/constants'
 import {
   type Bookmark,
   type BookmarkEntity,
@@ -172,6 +176,14 @@ export class BookmarkDatabase extends Dexie {
     const validatedIds = reorderBookmarksInputSchema.parse({ ids }).ids
 
     return await this.transaction('rw', this.bookmarks, async () => {
+      // 1. DB にある総件数を取得
+      const totalCount = await this.bookmarks.count()
+
+      // 2. 送られてきた件数と比較（全件送信を強制する）
+      if (validatedIds.length !== totalCount) {
+        throw new Error(VALIDATION_MESSAGES.REORDER_COUNT_MISMATCH)
+      }
+
       // 全ての ID が存在するか、件数をチェック
       const existingCount = await this.bookmarks
         .where('id')

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -462,6 +462,8 @@ export const VALIDATION_MESSAGES = {
   REORDER_DUPLICATE_IDS: 'IDリストに重複が含まれています',
   BOOKMARK_STATUS_REQUIRED_BOOKMARKID:
     '登録済み、変更ありの場合にはBOOKMARK IDが必要です',
+  REORDER_COUNT_MISMATCH:
+    '並べ替え対象の件数が一致しません。全件を指定してください',
 } as const
 
 /**


### PR DESCRIPTION
Issue #501
`REORDER_BOOKMARKS` アクション（`db.reorderBookmarks`）において、フロントエンドから送られてきた ID リストの件数が、IndexedDB 内の全データ総数と完全に一致することを保証するバリデーションを追加しました。

## 変更内容
- `shared/constants.ts`: `VALIDATION_MESSAGES.REORDER_COUNT_MISMATCH` 定数を新設。
- `extension/src/lib/idb.ts`: `reorderBookmarks` 内に件数一致チェックロジックを追加。
- `extension/src/lib/bookmark-reorder-idb.test.ts`:
    - 件数が「少ない場合」および「多い場合」の異常系テストケースを追加。
    - 既存のテストケースを新仕様（全件送信必須）に合わせて調整。

これにより、部分的な ID リストによる意図しない順序の破壊や不整合を、データベース層で確実に防げるようになりました。