### PR TITLE
[Frontend] useBookmarks フックの DELETE_BOOKMARK テスト復旧

### DIFF
--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -33,80 +33,166 @@ describe('useBookmarks Hook', () => {
     vi.clearAllMocks()
   })
 
-  it('ブックマーク一覧を取得できること', async () => {
-    // 1. 拡張機能からのレスポンスをモック
-    vi.mocked(chrome.runtime.sendMessage).mockImplementation(
-      (message, callback) => {
-        const parsed = ApiRequestSchema.safeParse(message)
+  describe('READ_BOOKMARKS', () => {
+    it('ブックマーク一覧を取得できること', async () => {
+      // 1. 拡張機能からのレスポンスをモック
+      vi.mocked(chrome.runtime.sendMessage).mockImplementation(
+        (message, callback) => {
+          const parsed = ApiRequestSchema.safeParse(message)
 
-        if (parsed.success) {
-          // このブロック内では、parsed.data は正しいリクエスト型として扱えます
-          if (parsed.data.action === API_ACTIONS.READ_BOOKMARKS) {
-            // ✅ 2. コールバックも関数であることを型ガードで確認
-            if (typeof callback === 'function') {
-              callback({
-                success: true,
-                data: { bookmarks: MOCK_BOOKMARKS },
-              })
+          if (parsed.success) {
+            // このブロック内では、parsed.data は正しいリクエスト型として扱えます
+            if (parsed.data.action === API_ACTIONS.READ_BOOKMARKS) {
+              // ✅ 2. コールバックも関数であることを型ガードで確認
+              if (typeof callback === 'function') {
+                callback({
+                  success: true,
+                  data: { bookmarks: MOCK_BOOKMARKS },
+                })
+              }
             }
           }
-        }
-      },
-    )
+        },
+      )
 
-    const { result } = renderHook(() => useBookmarks())
+      const { result } = renderHook(() => useBookmarks())
 
-    // 2. データが読み込まれるのを待つ
-    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      // 2. データが読み込まれるのを待つ
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
-    // 3. 結果の検証
-    expect(result.current.data?.bookmarks).toEqual(MOCK_BOOKMARKS)
-  })
+      // 3. 結果の検証
+      expect(result.current.data?.bookmarks).toEqual(MOCK_BOOKMARKS)
+    })
 
-  it.each([
-    {
-      testName: 'APIエラー',
-      params: {
-        success: false,
-        error: {
+    it.each([
+      {
+        testName: 'APIエラー',
+        params: {
+          success: false,
+          error: {
+            message: UI_MESSAGES.FETCH_BOOKMARKS_FAILED,
+            code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          },
+        },
+        expected: {
           message: UI_MESSAGES.FETCH_BOOKMARKS_FAILED,
           code: ERROR_CODES.INTERNAL_SERVER_ERROR,
         },
       },
-      expected: {
-        message: UI_MESSAGES.FETCH_BOOKMARKS_FAILED,
-        code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+      {
+        testName: '不正なレスポンス形式',
+        params: null,
+        expected: {
+          message: UI_MESSAGES.INVALID_RESPONSE_FROM_EXTENTION,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
       },
-    },
-    {
-      testName: '不正なレスポンス形式',
-      params: null,
-      expected: {
-        message: UI_MESSAGES.INVALID_RESPONSE_FROM_EXTENTION,
-        code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+    ])('エラー処理: $testName', async ({ params, expected }) => {
+      vi.mocked(chrome.runtime.sendMessage).mockImplementation(
+        (_message, callback) => {
+          if (typeof callback === 'function') {
+            callback(params)
+          }
+        },
+      )
+
+      const { result } = renderHook(() => useBookmarks())
+
+      // 2. エラー状態になるのを待つ
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      const error = result.current.error
+      if (error instanceof BookmarkApiError) {
+        expect(error.message).toBe(expected.message)
+        expect(error.code).toBe(expected.code)
+      } else {
+        expect(error).toBeInstanceOf(BookmarkApiError)
+      }
+    })
+  })
+
+  describe('DELETE_BOOKMARK', () => {
+    it('useDeleteBookmark が正常に動作すること', async () => {
+      // 1. メッセージ送信をモック
+      vi.mocked(chrome.runtime.sendMessage).mockImplementation(
+        (message, callback) => {
+          const parsed = ApiRequestSchema.safeParse(message)
+          if (
+            parsed.success &&
+            parsed.data.action === API_ACTIONS.DELETE_BOOKMARK
+          ) {
+            if (typeof callback === 'function') {
+              // 削除成功時は data: null を返却
+              callback({ success: true, data: null })
+            }
+          }
+        },
+      )
+
+      const { result } = renderHook(() => useDeleteBookmark())
+
+      // 2. 削除の実行
+      result.current.mutate(MOCK_BOOKMARK_1.id)
+
+      // 3. 成功状態になるのを待つ
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      // 4. メッセージが正しい ID で呼ばれたか検証
+      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: API_ACTIONS.DELETE_BOOKMARK,
+          payload: { id: MOCK_BOOKMARK_1.id },
+        }),
+        expect.any(Function),
+      )
+    })
+
+    it.each([
+      {
+        testName: '削除に失敗',
+        params: {
+          success: false,
+          error: {
+            message: UI_MESSAGES.DELETE_FAILED,
+            code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          },
+        },
+        expected: {
+          message: UI_MESSAGES.DELETE_FAILED,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
       },
-    },
-  ])('エラー処理: $testName', async ({ params, expected }) => {
-    vi.mocked(chrome.runtime.sendMessage).mockImplementation(
-      (_message, callback) => {
-        if (typeof callback === 'function') {
-          callback(params)
-        }
+      {
+        testName: '不正なレスポンス形式',
+        params: null,
+        expected: {
+          message: UI_MESSAGES.INVALID_RESPONSE_FROM_EXTENTION,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
       },
-    )
+    ])('エラー処理: $testName', async ({ params, expected }) => {
+      vi.mocked(chrome.runtime.sendMessage).mockImplementation(
+        (_message, callback) => {
+          if (typeof callback === 'function') {
+            callback(params)
+          }
+        },
+      )
 
-    const { result } = renderHook(() => useBookmarks())
+      const { result } = renderHook(() => useDeleteBookmark())
+      result.current.mutate(MOCK_BOOKMARK_1.id)
 
-    // 2. エラー状態になるのを待つ
-    await waitFor(() => expect(result.current.isError).toBe(true))
+      // 2. エラー状態になるのを待つ
+      await waitFor(() => expect(result.current.isError).toBe(true))
 
-    const error = result.current.error
-    if (error instanceof BookmarkApiError) {
-      expect(error.message).toBe(expected.message)
-      expect(error.code).toBe(expected.code)
-    } else {
-      expect(error).toBeInstanceOf(BookmarkApiError)
-    }
+      const error = result.current.error
+      if (error instanceof BookmarkApiError) {
+        expect(error.message).toBe(expected.message)
+        expect(error.code).toBe(expected.code)
+      } else {
+        expect(error).toBeInstanceOf(BookmarkApiError)
+      }
+    })
   })
 })
 
@@ -125,22 +211,6 @@ describe.skip('useBookmarks Hook (skip)', () => {
     result.current.mutate({ id: MOCK_BOOKMARK_1.id, updates: { title: 'New' } })
 
     await waitFor(() => expect(patchCalled).toBe(true))
-  })
-
-  it('useDeleteBookmark が正常に動作すること', async () => {
-    let deleteCalled = false
-    server.use(
-      http.delete(`*${API_PATHS.BOOKMARKS}/:id`, () => {
-        deleteCalled = true
-        return new HttpResponse(null, { status: 204 })
-      }),
-    )
-
-    const { result } = renderHook(() => useDeleteBookmark())
-
-    result.current.mutate(MOCK_BOOKMARK_1.id)
-
-    await waitFor(() => expect(deleteCalled).toBe(true))
   })
 
   it('useDeleteBookmark がエラー時にエラーを投げること', async () => {

--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -29,39 +29,72 @@ import { server } from '../test/setup'
 import { renderHook, waitFor } from '../test/utils'
 
 describe('useBookmarks Hook', () => {
+  const mockMessage = (action: string, params: unknown) => {
+    vi.mocked(chrome.runtime.sendMessage).mockImplementation(
+      (message, callback) => {
+        const parsed = ApiRequestSchema.safeParse(message)
+
+        if (
+          parsed.success &&
+          parsed.data.action === action &&
+          typeof callback === 'function'
+        ) {
+          callback(params)
+        }
+      },
+    )
+  }
+
+  const verifySuccess = async (
+    result: { current: { isSuccess: boolean; data?: unknown } },
+    action: string,
+    payload: unknown,
+    data: unknown,
+  ) => {
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action,
+        payload,
+      }),
+      expect.any(Function),
+    )
+    expect(result.current.data).toEqual(data)
+  }
+
+  const verifyError = async (
+    result: {
+      current: { isSuccess?: boolean; isError?: boolean; error: unknown }
+    },
+    expected: { message: string; code: string },
+  ) => {
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    const error = result.current.error
+    if (error instanceof BookmarkApiError) {
+      expect(error.message).toBe(expected.message)
+      expect(error.code).toBe(expected.code)
+    } else {
+      expect(error).toBeInstanceOf(BookmarkApiError)
+    }
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   describe('READ_BOOKMARKS', () => {
     it('ブックマーク一覧を取得できること', async () => {
-      // 1. 拡張機能からのレスポンスをモック
-      vi.mocked(chrome.runtime.sendMessage).mockImplementation(
-        (message, callback) => {
-          const parsed = ApiRequestSchema.safeParse(message)
-
-          if (parsed.success) {
-            // このブロック内では、parsed.data は正しいリクエスト型として扱えます
-            if (parsed.data.action === API_ACTIONS.READ_BOOKMARKS) {
-              // ✅ 2. コールバックも関数であることを型ガードで確認
-              if (typeof callback === 'function') {
-                callback({
-                  success: true,
-                  data: { bookmarks: MOCK_BOOKMARKS },
-                })
-              }
-            }
-          }
-        },
-      )
+      mockMessage(API_ACTIONS.READ_BOOKMARKS, {
+        success: true,
+        data: { bookmarks: MOCK_BOOKMARKS },
+      })
 
       const { result } = renderHook(() => useBookmarks())
 
-      // 2. データが読み込まれるのを待つ
-      await waitFor(() => expect(result.current.isSuccess).toBe(true))
-
-      // 3. 結果の検証
-      expect(result.current.data?.bookmarks).toEqual(MOCK_BOOKMARKS)
+      await verifySuccess(result, API_ACTIONS.READ_BOOKMARKS, undefined, {
+        bookmarks: MOCK_BOOKMARKS,
+      })
     })
 
     it.each([
@@ -88,63 +121,24 @@ describe('useBookmarks Hook', () => {
         },
       },
     ])('エラー処理: $testName', async ({ params, expected }) => {
-      vi.mocked(chrome.runtime.sendMessage).mockImplementation(
-        (_message, callback) => {
-          if (typeof callback === 'function') {
-            callback(params)
-          }
-        },
-      )
+      mockMessage(API_ACTIONS.READ_BOOKMARKS, params)
 
       const { result } = renderHook(() => useBookmarks())
 
-      // 2. エラー状態になるのを待つ
-      await waitFor(() => expect(result.current.isError).toBe(true))
-
-      const error = result.current.error
-      if (error instanceof BookmarkApiError) {
-        expect(error.message).toBe(expected.message)
-        expect(error.code).toBe(expected.code)
-      } else {
-        expect(error).toBeInstanceOf(BookmarkApiError)
-      }
+      await verifyError(result, expected)
     })
   })
 
   describe('DELETE_BOOKMARK', () => {
     it('useDeleteBookmark が正常に動作すること', async () => {
-      // 1. メッセージ送信をモック
-      vi.mocked(chrome.runtime.sendMessage).mockImplementation(
-        (message, callback) => {
-          const parsed = ApiRequestSchema.safeParse(message)
-          if (
-            parsed.success &&
-            parsed.data.action === API_ACTIONS.DELETE_BOOKMARK
-          ) {
-            if (typeof callback === 'function') {
-              // 削除成功時は data: null を返却
-              callback({ success: true, data: null })
-            }
-          }
-        },
-      )
+      const id = MOCK_BOOKMARK_1.id
+
+      mockMessage(API_ACTIONS.DELETE_BOOKMARK, { success: true, data: null })
 
       const { result } = renderHook(() => useDeleteBookmark())
+      result.current.mutate(id)
 
-      // 2. 削除の実行
-      result.current.mutate(MOCK_BOOKMARK_1.id)
-
-      // 3. 成功状態になるのを待つ
-      await waitFor(() => expect(result.current.isSuccess).toBe(true))
-
-      // 4. メッセージが正しい ID で呼ばれたか検証
-      expect(chrome.runtime.sendMessage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: API_ACTIONS.DELETE_BOOKMARK,
-          payload: { id: MOCK_BOOKMARK_1.id },
-        }),
-        expect.any(Function),
-      )
+      await verifySuccess(result, API_ACTIONS.DELETE_BOOKMARK, { id }, null)
     })
 
     it.each([
@@ -171,27 +165,12 @@ describe('useBookmarks Hook', () => {
         },
       },
     ])('エラー処理: $testName', async ({ params, expected }) => {
-      vi.mocked(chrome.runtime.sendMessage).mockImplementation(
-        (_message, callback) => {
-          if (typeof callback === 'function') {
-            callback(params)
-          }
-        },
-      )
+      mockMessage(API_ACTIONS.DELETE_BOOKMARK, params)
 
       const { result } = renderHook(() => useDeleteBookmark())
       result.current.mutate(MOCK_BOOKMARK_1.id)
 
-      // 2. エラー状態になるのを待つ
-      await waitFor(() => expect(result.current.isError).toBe(true))
-
-      const error = result.current.error
-      if (error instanceof BookmarkApiError) {
-        expect(error.message).toBe(expected.message)
-        expect(error.code).toBe(expected.code)
-      } else {
-        expect(error).toBeInstanceOf(BookmarkApiError)
-      }
+      await verifyError(result, expected)
     })
   })
 })


### PR DESCRIPTION
Issue #516
`useBookmarks` フックにおける `DELETE_BOOKMARK`（ブックマーク削除）のテストを、新しいメッセージング基盤に合わせて復旧・刷新しました。

## 変更内容
- `src/hooks/useBookmarks.test.tsx`:
    - `DELETE_BOOKMARK` 関連のテストケースを `describe.skip` から復旧。
    - `chrome.runtime.sendMessage` をモックし、削除アクションの正常系・異常系を検証するように書き換え。
    - 成功後のメッセージ呼び出し内容（正しい ID が渡されているか）の検証を追加。
    - `instanceof BookmarkApiError` による厳格なエラー検証を適用。

本 PR により、Local-first 移行後のフロントエンドにおける「削除系」のテスト品質が確保されました。