### PR TITLE
[Frontend] REORDER_BOOKMARKS テストを最新の検証ヘルパー形式へリファクタリング

### DIFF
--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -305,18 +305,17 @@ describe('useBookmarks Hook', () => {
 
       result.current.hook.mutate(ids)
 
-      await waitFor(() => {
-        const cachedData = result.current.queryClient.getQueryData<Bookmarks>(
-          QUERY_KEYS.BOOKMARKS.LIST(),
-        )
-        expect(cachedData?.bookmarks).toEqual(expectedData)
-      })
-
       await verifySuccess(
         () => result.current.hook,
         API_ACTIONS.REORDER_BOOKMARKS,
         ids,
         null,
+        () =>
+          expect(
+            result.current.queryClient.getQueryData<Bookmarks>(
+              QUERY_KEYS.BOOKMARKS.LIST(),
+            ),
+          ).toEqual({ bookmarks: expectedData }),
       )
     })
 
@@ -380,13 +379,15 @@ describe('useBookmarks Hook', () => {
         API_ACTIONS.REORDER_BOOKMARKS,
         ids,
         expected,
+        () =>
+          expect(
+            result.current.queryClient.getQueryData<Bookmarks>(
+              QUERY_KEYS.BOOKMARKS.LIST(),
+            ),
+          ).toEqual({
+            bookmarks: MOCK_BOOKMARKS,
+          }),
       )
-
-      expect(
-        result.current.queryClient.getQueryData(QUERY_KEYS.BOOKMARKS.LIST()),
-      ).toEqual({
-        bookmarks: MOCK_BOOKMARKS,
-      })
 
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining(


### PR DESCRIPTION
Issue #530
`REORDER_BOOKMARKS` のテストにおいて、個別の `waitFor` によるキャッシュ検証ロジックを `verifySuccess` / `verifyError` の `extraAssertions` 内に統合しました。

## 変更内容
- `REORDER_BOOKMARKS` の正常系および異常系のテスト記述を刷新
- 全ての検証を単一の `waitFor` 内で行うように整理し、一貫性を向上

これにより、ファイル内の全テストが最高品質の検証パターンに統一されました。