### PR TITLE
[Frontend] useBookmarkPage におけるキーワード振り分けロジックの検証復旧

### DIFF
--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -63,19 +63,20 @@ describe('useBookmarkPage Hook', () => {
     expect(result.current.editTitle).toBe(MOCK_BOOKMARK_1.title)
     expect(result.current.editUrl).toBe(MOCK_BOOKMARK_1.url)
   })
-})
-
-describe.skip('useBookmarkPage Hook (skip)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
 
   it('未割当キーワードが、全キーワードから割当済みを除外して正しく計算されること', async () => {
     // 最初のキーワードが割当済みのブックマークとしてモックを上書き
-    // const bookmarkWithKeyword = {
-    //   ...MOCK_BOOKMARK_1,
-    //   keywords: [MOCK_KEYWORDS[0]],
-    // }
+    mockMessage(API_ACTIONS.READ_BOOKMARKS, {
+      success: true,
+      data: {
+        bookmarks: [
+          {
+            ...MOCK_BOOKMARK_1,
+            keywords: [MOCK_KEYWORDS[0]],
+          },
+        ],
+      },
+    })
 
     const { result } = renderHook(() => useBookmarkPage())
 
@@ -84,6 +85,12 @@ describe.skip('useBookmarkPage Hook (skip)', () => {
 
     // 1番目以外が残っていることを確認
     expect(result.current.unassignedKeywords).toEqual(MOCK_KEYWORDS.slice(1))
+  })
+})
+
+describe.skip('useBookmarkPage Hook (skip)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
   it('handleUpdate が成功した際、一覧へ戻ること', async () => {


### PR DESCRIPTION
Issue #542
`useBookmarkPage` フックにおける、キーワードの「未割当/割当済み」のフィルタリング・計算ロジックに関するテストを復旧しました。

## 変更内容
- `src/hooks/useBookmarkPage.test.ts`:
    - 「未割当キーワードが、全キーワードから割当済みを除外して正しく計算されること」のテストを `describe.skip` から復旧。
    - 以前の PR で導入した「チェイン可能な `mockMessage`」を活用し、テストケースごとに特定のデータのみを上書きする効率的な検証を実装。

本 PR により、複雑なキーワード振り分けステートの正確性が保証されました。