### PR TITLE
[Frontend] useBookmarkPage における handleDelete の検証復旧

### DIFF
--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -117,22 +117,36 @@ describe('useBookmarkPage Hook', () => {
       },
     })
   })
-})
-
-describe.skip('useBookmarkPage Hook (skip)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
 
   it('handleDelete が成功した際、一覧へ戻ること (Hook は確認ダイアログを担当しない)', async () => {
+    mockMessage(API_ACTIONS.DELETE_BOOKMARK, {
+      success: true,
+      data: null,
+    })
     const { result } = renderHook(() => useBookmarkPage())
-    await waitFor(() => expect(result.current.bookmark).not.toBeUndefined())
+
+    // データロード完了を待機
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     await act(async () => {
       await result.current.handleDelete()
     })
 
-    expect(mockNavigate).toHaveBeenCalledWith(APP_PATHS.HOME)
+    await verifySuccess({
+      action: API_ACTIONS.DELETE_BOOKMARK,
+      payload: { id: MOCK_BOOKMARK_1.id },
+      data: null,
+      extraAssertions: () => {
+        expect(result.current.isDeleting).toBe(false)
+        expect(mockNavigate).toHaveBeenCalledWith(APP_PATHS.HOME)
+      },
+    })
+  })
+})
+
+describe.skip('useBookmarkPage Hook (skip)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
   it('handleOpen が呼ばれた際、openUrlInNewTab を実行すること', async () => {


### PR DESCRIPTION
Issue #546
`useBookmarkPage` フックにおける `handleDelete`（ブックマーク削除）のテストを、メッセージング基盤に合わせて復旧しました。

## 変更内容
- `src/hooks/useBookmarkPage.test.ts`:
    - `handleDelete` 関連のテストを `describe.skip` から復旧。
    - 刷新された `verifySuccess` ヘルパーを活用し、メッセージ送信と画面遷移（HOMEへの戻り）を単一の `waitFor` ブロック内で堅牢に検証。

本 PR により、詳細画面からの削除フローの品質が確保されました。