### PR TITLE
[Frontend] useBookmarkPage における handleBack の検証復旧

### DIFF
--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -183,16 +183,10 @@ describe('useBookmarkPage Hook', () => {
     // ✅ 通信の検証ではなく、副作用の検証を行う
     expect(urlUtils.openUrlInNewTab).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url)
   })
-})
 
-describe.skip('useBookmarkPage Hook (skip)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it('handleBack が呼ばれた際、onBack を実行し一覧へ戻ること', () => {
+  it('handleBack が呼ばれた際、onBack を実行し一覧へ戻ること', async () => {
     const onBack = vi.fn()
-    const { result } = renderHook(() => useBookmarkPage(onBack))
+    const result = await setupHook({ onBack })
 
     act(() => {
       result.current.handleBack()
@@ -200,6 +194,12 @@ describe.skip('useBookmarkPage Hook (skip)', () => {
 
     expect(onBack).toHaveBeenCalled()
     expect(mockNavigate).toHaveBeenCalledWith(APP_PATHS.HOME)
+  })
+})
+
+describe.skip('useBookmarkPage Hook (skip)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
   })
 
   it('handleKeywordKeyDown が Enter キーで handleCreateKeyword を呼び出すこと', async () => {


### PR DESCRIPTION
Issue #550
`useBookmarkPage` フックにおける画面戻り操作（`handleBack`）のテストを復旧しました。

## 変更内容
- `src/hooks/useBookmarkPage.test.ts`:
    - `handleBack` 関連のテストを `describe.skip` から復旧。
    - `setupHook` を活用し、初期化済みの状態でコールバックと画面遷移を検証。

本 PR により、詳細画面からの遷移系ロジックのテストが全て揃いました。