### PR TITLE
[Frontend] useBookmarkPage におけるキーワード入力フィールドのキーイベント (handleKeywordKeyDown) の検証復旧

### DIFF
--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -23,7 +23,12 @@ import * as urlUtils from '@shared/utils/url'
 import { useBookmarkPage } from './useBookmarkPage'
 import { createDragStartEvent, createDragEndEvent } from '../test/dnd-utils'
 import { createKeyboardEvent } from '../test/event-utils'
-import { mockMessage, verifyCalledMessage, verifySuccess } from '../test/mock'
+import {
+  mockMessage,
+  verifyCalledMessage,
+  verifyKeywordStatus,
+  verifySuccess,
+} from '../test/mock'
 import { renderHook, act, waitFor } from '../test/utils'
 
 // モックの設定
@@ -479,29 +484,78 @@ describe('useBookmarkPage Hook', () => {
       })
     })
   })
+
+  describe('handleKeywordKeyDown', () => {
+    it('handleKeywordKeyDown が Enter キーで handleCreateKeyword を呼び出すこと', async () => {
+      const keywordName = TEST_STRINGS.NEW_NAME
+
+      // 1. 通信のモック（呼び出されることを確認するため）
+      mockMessage(API_ACTIONS.CREATE_KEYWORD, {
+        success: true,
+        data: {
+          keyword: { id: MOCK_IDS.NEW_KEYWORD, name: keywordName },
+        },
+      }).mockMessage(API_ACTIONS.ATTACH_KEYWORD, {
+        success: true,
+        data: MOCK_BOOKMARK_1,
+      })
+
+      const result = await setupHook({})
+
+      // 2. 入力を設定し、反映を待つ
+      await act(async () => {
+        result.current.setKeywordInput(keywordName)
+      })
+
+      // 3. Enter キーイベントをシミュレート
+      act(() => {
+        const event = createKeyboardEvent(KEY_VALUES.ENTER)
+        result.current.handleKeywordKeyDown(event)
+      })
+
+      // 4. 検証：通信が発生し、入力がクリアされること
+      await waitFor(() => {
+        verifyCalledMessage({
+          action: API_ACTIONS.CREATE_KEYWORD,
+          payload: { name: keywordName },
+        })
+        verifyKeywordStatus(() => result.current, '')
+      })
+    })
+
+    it.each([
+      {
+        testName: 'Enter以外のキー',
+        key: KEY_VALUES.SPACE,
+        options: undefined,
+      },
+      {
+        testName: 'Shift+Enter',
+        key: KEY_VALUES.ENTER,
+        options: { shiftKey: true },
+      },
+    ])(
+      '$testName が呼び出された場合にhandleCreateKeyword を呼び出さないこと',
+      async ({ key, options }) => {
+        const result = await setupHook({})
+        act(() => {
+          result.current.handleKeywordKeyDown(createKeyboardEvent(key, options))
+        })
+
+        await waitFor(() => {
+          verifyCalledMessage({
+            action: API_ACTIONS.CREATE_KEYWORD,
+            isNotCalled: true,
+          })
+        })
+      },
+    )
+  })
 })
 
 describe.skip('useBookmarkPage Hook (skip)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-  })
-
-  it('handleKeywordKeyDown が Enter キーで handleCreateKeyword を呼び出すこと', async () => {
-    const createCalled = false
-
-    const { result } = renderHook(() => useBookmarkPage())
-    await waitFor(() => expect(result.current.bookmark).not.toBeUndefined())
-
-    await act(async () => {
-      result.current.setKeywordInput('Enter')
-    })
-
-    act(() => {
-      const event = createKeyboardEvent(KEY_VALUES.ENTER)
-      result.current.handleKeywordKeyDown(event)
-    })
-
-    await waitFor(() => expect(createCalled).toBe(true))
   })
 
   describe('Drag and Drop Handlers', () => {

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -1,6 +1,7 @@
 import { expect, vi } from 'vitest'
 
 import { ApiRequestSchema } from '@shared/schemas/api'
+import type { Keyword } from '@shared/schemas/keyword'
 
 import { waitFor } from './utils'
 import { BookmarkApiError } from '../lib/api-client'
@@ -117,4 +118,17 @@ export const verifyError = async ({
     }
     if (extraAssertions) extraAssertions()
   })
+}
+
+export const verifyKeywordStatus = (
+  getHookState: () => {
+    keywordInput?: string
+    isKeywordProcessing?: boolean
+    activeKeyword?: Keyword | null
+  },
+  input: string,
+) => {
+  expect(getHookState().keywordInput).toBe(input)
+  expect(getHookState().isKeywordProcessing).toBe(false)
+  expect(getHookState().activeKeyword).toBeNull()
 }


### PR DESCRIPTION
## 概要
useBookmarkPage フックにおける `handleKeywordKeyDown` のテストを復旧しました。
Enter キーによる実行だけでなく、境界値（Shift+Enter, Enter 以外のキー）で正しく処理が抑制されることを検証しています。

## 変更内容
- `handleKeywordKeyDown` の正常系テストの追加
- `it.each` を用いた境界値（Shift+Enter, Space 等）の網羅的検証
- 基盤改善 (`src/test/mock.ts`): `verifyKeywordStatus` ヘルパーの導入
- 副作用（入力値クリア、処理中フラグ、アクティブキーワードの解除）の一括検証

## 関連 Issue
Close #557