### PR TITLE
[Refactor] verifyKeywordStatus ヘルパーを用いた副作用検証

### DIFF
--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -228,8 +228,7 @@ describe('useBookmarkPage Hook', () => {
       action: API_ACTIONS.ATTACH_KEYWORD,
       payload: { bookmarkId, keywordId },
       data: MOCK_BOOKMARK_1,
-      extraAssertions: () =>
-        expect(result.current.isKeywordProcessing).toBe(false),
+      extraAssertions: () => verifyKeywordStatus(() => result.current),
     })
   })
 
@@ -260,10 +259,7 @@ describe('useBookmarkPage Hook', () => {
       action: API_ACTIONS.ATTACH_KEYWORD,
       payload: { bookmarkId: bookmark.id, keywordId: keywordId },
       data: bookmark,
-      extraAssertions: () => {
-        expect(result.current.isKeywordProcessing).toBe(false)
-        expect(result.current.activeKeyword).toBeNull()
-      },
+      extraAssertions: () => verifyKeywordStatus(() => result.current),
     })
   })
 
@@ -295,8 +291,7 @@ describe('useBookmarkPage Hook', () => {
       action: API_ACTIONS.DETACH_KEYWORD,
       payload: { bookmarkId: bookmarkWithKeyword.id, keywordId },
       data: MOCK_BOOKMARK_1,
-      extraAssertions: () =>
-        expect(result.current.isKeywordProcessing).toBe(false),
+      extraAssertions: () => verifyKeywordStatus(() => result.current),
     })
   })
 
@@ -336,10 +331,7 @@ describe('useBookmarkPage Hook', () => {
       action: API_ACTIONS.DETACH_KEYWORD,
       payload: { bookmarkId: bookmarkWithKeyword.id, keywordId },
       data: MOCK_BOOKMARK_1,
-      extraAssertions: () => {
-        expect(result.current.isKeywordProcessing).toBe(false)
-        expect(result.current.activeKeyword).toBeNull()
-      },
+      extraAssertions: () => verifyKeywordStatus(() => result.current),
     })
   })
 
@@ -385,8 +377,7 @@ describe('useBookmarkPage Hook', () => {
           },
         })
         // 副作用の検証
-        expect(result.current.keywordInput).toBe('')
-        expect(result.current.isKeywordProcessing).toBe(false)
+        verifyKeywordStatus(() => result.current)
       })
     })
 
@@ -431,8 +422,7 @@ describe('useBookmarkPage Hook', () => {
             isNotCalled: true,
           })
 
-          expect(result.current.keywordInput).toBe(TEST_STRINGS.NEW_NAME)
-          expect(result.current.isKeywordProcessing).toBe(false)
+          verifyKeywordStatus(() => result.current, TEST_STRINGS.NEW_NAME)
 
           // ログ出力を確認
           expect(consoleSpy).toHaveBeenCalledWith(
@@ -473,8 +463,8 @@ describe('useBookmarkPage Hook', () => {
           // ❌ ATTACH_KEYWORD も呼ばれている
           verifyCalledMessage({ action: API_ACTIONS.ATTACH_KEYWORD })
 
-          expect(result.current.keywordInput).toBe(TEST_STRINGS.NEW_NAME)
-          expect(result.current.isKeywordProcessing).toBe(false)
+          verifyKeywordStatus(() => result.current, TEST_STRINGS.NEW_NAME)
+
           // ログ出力を確認
           expect(consoleSpy).toHaveBeenCalledWith(
             LOG_MESSAGES.ATTACH_KEYWORD_FAILED,
@@ -519,7 +509,7 @@ describe('useBookmarkPage Hook', () => {
           action: API_ACTIONS.CREATE_KEYWORD,
           payload: { name: keywordName },
         })
-        verifyKeywordStatus(() => result.current, '')
+        verifyKeywordStatus(() => result.current)
       })
     })
 

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -126,9 +126,10 @@ export const verifyKeywordStatus = (
     isKeywordProcessing?: boolean
     activeKeyword?: Keyword | null
   },
-  input: string,
+  input: string = '',
 ) => {
-  expect(getHookState().keywordInput).toBe(input)
-  expect(getHookState().isKeywordProcessing).toBe(false)
-  expect(getHookState().activeKeyword).toBeNull()
+  const state = getHookState()
+  expect(state.isKeywordProcessing).toBe(false)
+  expect(state.activeKeyword).toBeNull()
+  expect(state.keywordInput).toBe(input)
 }


### PR DESCRIPTION
## 概要
`useBookmarkPage.test.ts` 内のキーワード操作に関する副作用の検証を、`verifyKeywordStatus` ヘルパーを用いて統一しました。

## 変更内容
- **基盤改善 (`src/test/mock.ts`)**: `verifyKeywordStatus` の第2引数（期待する入力値）にデフォルト値 `''` を設定。
- **リファクタリング**: `handleAttachKeyword`, `handleDetachKeyword`, DnD, `handleCreateKeyword` の各テストにおける副作用検証を一括検証ヘルパーに置き換え。
- **検証の強化**: 全てのキーワード操作テストにおいて、入力値・処理中フラグ・アクティブキーワードの3点が常にセットで検証されるようになりました。

## 関連 Issue
Close #561