### PR TITLE
[Refactor/Test] verifyKeywordStatus の拡張と DnD 開始・ガード節の検証復旧

### DIFF
--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -422,7 +422,9 @@ describe('useBookmarkPage Hook', () => {
             isNotCalled: true,
           })
 
-          verifyKeywordStatus(() => result.current, TEST_STRINGS.NEW_NAME)
+          verifyKeywordStatus(() => result.current, {
+            keywordInput: TEST_STRINGS.NEW_NAME,
+          })
 
           // ログ出力を確認
           expect(consoleSpy).toHaveBeenCalledWith(
@@ -463,7 +465,9 @@ describe('useBookmarkPage Hook', () => {
           // ❌ ATTACH_KEYWORD も呼ばれている
           verifyCalledMessage({ action: API_ACTIONS.ATTACH_KEYWORD })
 
-          verifyKeywordStatus(() => result.current, TEST_STRINGS.NEW_NAME)
+          verifyKeywordStatus(() => result.current, {
+            keywordInput: TEST_STRINGS.NEW_NAME,
+          })
 
           // ログ出力を確認
           expect(consoleSpy).toHaveBeenCalledWith(
@@ -541,45 +545,47 @@ describe('useBookmarkPage Hook', () => {
       },
     )
   })
+
+  describe('handleDragStartとhandleDragEnd', () => {
+    it('handleDragStart が activeKeyword を設定すること', async () => {
+      const result = await setupHook({})
+      const keyword = MOCK_KEYWORDS[1]
+
+      act(() => {
+        result.current.handleDragStart(createDragStartEvent(keyword.id))
+      })
+
+      // 拡張したヘルパーで、activeKeyword が設定されていることを検証
+      verifyKeywordStatus(() => result.current, { activeKeyword: keyword })
+    })
+
+    it('handleDragEnd が無効なドロップ先では何もしないこと', async () => {
+      const result = await setupHook({})
+      const keywordId = MOCK_KEYWORDS[1].id
+
+      await act(async () => {
+        result.current.handleDragEnd(
+          createDragEndEvent(keywordId, DROPPABLE_IDS.UNASSIGNED_LIST),
+        )
+      })
+
+      // 検証：通信が発生していないこと、および状態がリセットされていること
+      verifyCalledMessage({
+        action: API_ACTIONS.ATTACH_KEYWORD,
+        isNotCalled: true,
+      })
+      verifyCalledMessage({
+        action: API_ACTIONS.DETACH_KEYWORD,
+        isNotCalled: true,
+      })
+      verifyKeywordStatus(() => result.current)
+    })
+  })
 })
 
 describe.skip('useBookmarkPage Hook (skip)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-  })
-
-  describe('Drag and Drop Handlers', () => {
-    it('handleDragStart が activeKeyword を設定すること', async () => {
-      const { result } = renderHook(() => useBookmarkPage())
-      await waitFor(() => expect(result.current.bookmark).not.toBeUndefined())
-
-      act(() => {
-        result.current.handleDragStart(
-          createDragStartEvent(MOCK_KEYWORDS[1].id),
-        )
-      })
-
-      expect(result.current.activeKeyword?.id).toBe(MOCK_KEYWORDS[1].id)
-    })
-
-    it('handleDragEnd が未割当領域へのドロップでは何もしないこと', async () => {
-      const attachCalled = false
-
-      const { result } = renderHook(() => useBookmarkPage())
-      await waitFor(() => expect(result.current.bookmark).not.toBeUndefined())
-
-      await act(async () => {
-        result.current.handleDragEnd(
-          createDragEndEvent(
-            MOCK_KEYWORDS[1].id,
-            DROPPABLE_IDS.UNASSIGNED_LIST,
-          ),
-        )
-      })
-
-      expect(attachCalled).toBe(false)
-      expect(result.current.activeKeyword).toBeNull()
-    })
   })
 
   describe('Keyboard shortcuts', () => {

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -126,10 +126,20 @@ export const verifyKeywordStatus = (
     isKeywordProcessing?: boolean
     activeKeyword?: Keyword | null
   },
-  input: string = '',
+  options: {
+    keywordInput?: string
+    isKeywordProcessing?: boolean
+    activeKeyword?: Keyword | null
+  } = {},
 ) => {
+  const {
+    keywordInput = '',
+    isKeywordProcessing = false,
+    activeKeyword = null,
+  } = options
+
   const state = getHookState()
-  expect(state.isKeywordProcessing).toBe(false)
-  expect(state.activeKeyword).toBeNull()
-  expect(state.keywordInput).toBe(input)
+  expect(state.isKeywordProcessing).toBe(isKeywordProcessing)
+  expect(state.activeKeyword).toEqual(activeKeyword)
+  expect(state.keywordInput).toBe(keywordInput)
 }


### PR DESCRIPTION
## 概要
`verifyKeywordStatus` ヘルパーを拡張し、`activeKeyword` や `isKeywordProcessing` の具体的な状態も検証可能にしました。
その上で、`useBookmarkPage` におけるドラッグ開始 (`handleDragStart`) と、無効なドロップ先への操作時のガード節のテストを復旧しました。

## 変更内容
- **基盤改善 (`src/test/mock.ts`)**: `verifyKeywordStatus` がオプションオブジェクトを受け取れるように拡張。
- **テスト復旧**: 
    - `handleDragStart` の検証（`activeKeyword` の設定確認）。
    - `handleDragEnd` のガード節の検証（無効なドロップ先で通信が発生しないことの確認）。
- **リファクタリング**: DnD 関連のテストを `describe` ブロックに集約。

## 関連 Issue
Close #563