### PR TITLE
[Refactor] useBookmarkPage.navigation.test.ts における遷移検証の標準化

### DIFF
--- a/src/hooks/useBookmarkPage.navigation.test.ts
+++ b/src/hooks/useBookmarkPage.navigation.test.ts
@@ -8,7 +8,7 @@ import * as urlUtils from '@shared/utils/url'
 import { openUrlInNewTab } from '@shared/utils/url'
 
 import { commonSetup, setupHook } from './useBookmarkPage.test-utils'
-import { mockNavigate, verifySuccess } from '../test/mock'
+import { mockNavigate, verifyNavigateToPath, verifySuccess } from '../test/mock'
 import { fireEvent } from '../test/utils'
 
 // react-router-dom のモックはファイルごとに必要
@@ -45,7 +45,7 @@ describe('useBookmarkPage Hook - Navigation & Shortcuts', () => {
       })
 
       expect(onBack).toHaveBeenCalled()
-      expect(mockNavigate).toHaveBeenCalledWith(APP_PATHS.HOME)
+      verifyNavigateToPath(APP_PATHS.HOME)
     })
 
     it('handleOpen が呼ばれた際、URL を別タブで開くこと', async () => {
@@ -55,7 +55,7 @@ describe('useBookmarkPage Hook - Navigation & Shortcuts', () => {
         result.current.handleOpen()
       })
 
-      expect(openUrlInNewTab).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url)
+      verifyNavigateToPath(MOCK_BOOKMARK_1.url, openUrlInNewTab)
     })
   })
 
@@ -63,13 +63,13 @@ describe('useBookmarkPage Hook - Navigation & Shortcuts', () => {
     it('Escape キーで handleBack が呼ばれること', async () => {
       await setupHook()
       fireEvent.keyDown(window, { key: KEY_VALUES.ESCAPE })
-      expect(mockNavigate).toHaveBeenCalledWith(APP_PATHS.HOME)
+      verifyNavigateToPath(APP_PATHS.HOME)
     })
 
     it('Enter キー単体で handleOpen が呼ばれること', async () => {
       await setupHook()
       fireEvent.keyDown(window, { key: KEY_VALUES.ENTER })
-      expect(openUrlInNewTab).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url)
+      verifyNavigateToPath(MOCK_BOOKMARK_1.url, openUrlInNewTab)
     })
 
     it('Ctrl + Enter キーで handleUpdate が呼ばれること', async () => {

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -10,8 +10,11 @@ import { BookmarkApiError } from '../lib/api-client'
 export const mockNavigate = vi.fn()
 
 //  指定されたパスへの遷移が行われたことを検証する
-export const verifyNavigateToPath = (path: string) => {
-  expect(mockNavigate).toHaveBeenCalledWith(path)
+export const verifyNavigateToPath = (
+  path: string,
+  navigation: (url: string) => void = mockNavigate,
+) => {
+  expect(navigation).toHaveBeenCalledWith(path)
 }
 
 /**


### PR DESCRIPTION
## 概要
`useBookmarkPage.navigation.test.ts` において、遷移（navigate および openUrlInNewTab）の検証を標準化された `verifyNavigateToPath` へ置き換え、記述を統一しました。

## 変更内容
- `handleBack` および Escape ショートカットの検証を `verifyNavigateToPath` に変更
- `handleOpen` および Enter ショートカットの検証を `verifyNavigateToPath`（第2引数に `openUrlInNewTab` を指定）に変更

## 関連 Issue
Close #574