### PR TITLE
[Test] useBookmarkPage.bookmark.test.ts における API エラー検証の追加

### DIFF
--- a/src/hooks/useBookmarkPage.bookmark.test.ts
+++ b/src/hooks/useBookmarkPage.bookmark.test.ts
@@ -77,36 +77,76 @@ describe('useBookmarkPage Hook - Bookmark Operations', () => {
 
       await verifyError({
         action: API_ACTIONS.UPDATE_BOOKMARK,
+        payload: {
+          id: MOCK_BOOKMARK_1.id,
+          title: MOCK_BOOKMARK_1.title,
+          url: MOCK_BOOKMARK_1.url,
+        },
         expected: {
           message: UI_MESSAGES.UPDATE_FAILED,
           code: ERROR_CODES.INTERNAL_SERVER_ERROR,
         },
         logMessage: LOG_MESSAGES.UPDATE_BOOKMARK_FAILED,
         consoleSpy,
+        navigateToPath: { isNotCalled: true },
       })
     })
   })
 
-  it('handleDelete が成功した際、一覧へ戻ること (Hook は確認ダイアログを担当しない)', async () => {
-    const result = await setupHook({
-      mock: {
-        action: API_ACTIONS.DELETE_BOOKMARK,
-        params: {
-          success: true,
-          data: null,
+  describe('handleDelete', () => {
+    it('handleDelete が成功した際、一覧へ戻ること (Hook は確認ダイアログを担当しない)', async () => {
+      const result = await setupHook({
+        mock: {
+          action: API_ACTIONS.DELETE_BOOKMARK,
+          params: {
+            success: true,
+            data: null,
+          },
         },
-      },
+      })
+
+      await act(async () => {
+        await result.current.handleDelete()
+      })
+
+      await verifySuccess({
+        action: API_ACTIONS.DELETE_BOOKMARK,
+        payload: { id: MOCK_BOOKMARK_1.id },
+        expectedData: null,
+        path: APP_PATHS.HOME,
+      })
     })
 
-    await act(async () => {
-      await result.current.handleDelete()
-    })
+    it('handleDelete の API エラー時にログ出力すること', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const result = await setupHook({
+        mock: {
+          action: API_ACTIONS.DELETE_BOOKMARK,
+          params: {
+            success: false,
+            error: {
+              message: UI_MESSAGES.DELETE_FAILED,
+              code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+            },
+          },
+        },
+      })
 
-    await verifySuccess({
-      action: API_ACTIONS.DELETE_BOOKMARK,
-      payload: { id: MOCK_BOOKMARK_1.id },
-      expectedData: null,
-      path: APP_PATHS.HOME,
+      await act(async () => {
+        await result.current.handleDelete()
+      })
+
+      await verifyError({
+        action: API_ACTIONS.DELETE_BOOKMARK,
+        payload: { id: MOCK_BOOKMARK_1.id },
+        expected: {
+          message: UI_MESSAGES.DELETE_FAILED,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
+        logMessage: LOG_MESSAGES.DELETE_BOOKMARK_FAILED,
+        consoleSpy,
+        navigateToPath: { isNotCalled: true },
+      })
     })
   })
 })

--- a/src/hooks/useBookmarkPage.bookmark.test.ts
+++ b/src/hooks/useBookmarkPage.bookmark.test.ts
@@ -1,10 +1,16 @@
 import { describe, it, vi, beforeEach } from 'vitest'
 
-import { API_ACTIONS, APP_PATHS } from '@shared/constants'
+import {
+  API_ACTIONS,
+  APP_PATHS,
+  ERROR_CODES,
+  LOG_MESSAGES,
+  UI_MESSAGES,
+} from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 
 import { commonSetup, setupHook } from './useBookmarkPage.test-utils'
-import { mockNavigate, verifySuccess } from '../test/mock'
+import { mockNavigate, verifyError, verifySuccess } from '../test/mock'
 import { act } from '../test/utils'
 
 // react-router-dom のモックはファイルごとに必要
@@ -21,32 +27,63 @@ describe('useBookmarkPage Hook - Bookmark Operations', () => {
   beforeEach(() => {
     commonSetup()
   })
-
-  it('handleUpdate が成功した際、一覧へ戻ること', async () => {
-    const result = await setupHook({
-      mock: {
-        action: API_ACTIONS.UPDATE_BOOKMARK,
-        params: {
-          success: true,
-          data: MOCK_BOOKMARK_1,
+  describe('handleUpdate', () => {
+    it('成功して一覧へ戻ること', async () => {
+      const result = await setupHook({
+        mock: {
+          action: API_ACTIONS.UPDATE_BOOKMARK,
+          params: {
+            success: true,
+            data: MOCK_BOOKMARK_1,
+          },
         },
-      },
+      })
+
+      // 2. 更新実行
+      await act(async () => {
+        await result.current.handleUpdate()
+      })
+
+      await verifySuccess({
+        action: API_ACTIONS.UPDATE_BOOKMARK,
+        payload: {
+          id: MOCK_BOOKMARK_1.id,
+          title: MOCK_BOOKMARK_1.title,
+          url: MOCK_BOOKMARK_1.url,
+        },
+        expectedData: MOCK_BOOKMARK_1,
+        path: APP_PATHS.HOME,
+      })
     })
 
-    // 2. 更新実行
-    await act(async () => {
-      await result.current.handleUpdate()
-    })
+    it('APIがエラーを返す場合', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const result = await setupHook({
+        mock: {
+          action: API_ACTIONS.UPDATE_BOOKMARK,
+          params: {
+            success: false,
+            error: {
+              message: UI_MESSAGES.UPDATE_FAILED,
+              code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+            },
+          },
+        },
+      })
 
-    await verifySuccess({
-      action: API_ACTIONS.UPDATE_BOOKMARK,
-      payload: {
-        id: MOCK_BOOKMARK_1.id,
-        title: MOCK_BOOKMARK_1.title,
-        url: MOCK_BOOKMARK_1.url,
-      },
-      expectedData: MOCK_BOOKMARK_1,
-      path: APP_PATHS.HOME,
+      await act(async () => {
+        await result.current.handleUpdate()
+      })
+
+      await verifyError({
+        action: API_ACTIONS.UPDATE_BOOKMARK,
+        expected: {
+          message: UI_MESSAGES.UPDATE_FAILED,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
+        logMessage: LOG_MESSAGES.UPDATE_BOOKMARK_FAILED,
+        consoleSpy,
+      })
     })
   })
 

--- a/src/hooks/useBookmarkPage.keywords.test.ts
+++ b/src/hooks/useBookmarkPage.keywords.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, vi, beforeEach, expect } from 'vitest'
+import { describe, it, vi, beforeEach, expect, type MockInstance } from 'vitest'
 
 import {
   API_ACTIONS,
@@ -188,7 +188,7 @@ describe('useBookmarkPage Hook - Bookmark Operations', () => {
     })
 
     describe('handleCreateKeyword の失敗', () => {
-      let consoleSpy: ReturnType<typeof vi.spyOn>
+      let consoleSpy: MockInstance
 
       beforeEach(() => {
         consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/hooks/useBookmarkPage.navigation.test.ts
+++ b/src/hooks/useBookmarkPage.navigation.test.ts
@@ -45,7 +45,7 @@ describe('useBookmarkPage Hook - Navigation & Shortcuts', () => {
       })
 
       expect(onBack).toHaveBeenCalled()
-      verifyNavigateToPath(APP_PATHS.HOME)
+      verifyNavigateToPath()
     })
 
     it('handleOpen が呼ばれた際、URL を別タブで開くこと', async () => {
@@ -55,7 +55,10 @@ describe('useBookmarkPage Hook - Navigation & Shortcuts', () => {
         result.current.handleOpen()
       })
 
-      verifyNavigateToPath(MOCK_BOOKMARK_1.url, openUrlInNewTab)
+      verifyNavigateToPath({
+        path: MOCK_BOOKMARK_1.url,
+        navigation: openUrlInNewTab,
+      })
     })
   })
 
@@ -63,13 +66,16 @@ describe('useBookmarkPage Hook - Navigation & Shortcuts', () => {
     it('Escape キーで handleBack が呼ばれること', async () => {
       await setupHook()
       fireEvent.keyDown(window, { key: KEY_VALUES.ESCAPE })
-      verifyNavigateToPath(APP_PATHS.HOME)
+      verifyNavigateToPath()
     })
 
     it('Enter キー単体で handleOpen が呼ばれること', async () => {
       await setupHook()
       fireEvent.keyDown(window, { key: KEY_VALUES.ENTER })
-      verifyNavigateToPath(MOCK_BOOKMARK_1.url, openUrlInNewTab)
+      verifyNavigateToPath({
+        path: MOCK_BOOKMARK_1.url,
+        navigation: openUrlInNewTab,
+      })
     })
 
     it('Ctrl + Enter キーで handleUpdate が呼ばれること', async () => {

--- a/src/hooks/useBookmarkPage.test-utils.ts
+++ b/src/hooks/useBookmarkPage.test-utils.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest'
+import { expect, vi, type MockInstance } from 'vitest'
 
 import { API_ACTIONS } from '@shared/constants'
 import type { Bookmark, Keyword } from '@shared/schemas/bookmark'
@@ -75,7 +75,7 @@ export const verifyActionFailure = async ({
   calledMessages: CallMessagesParams[]
   logMessage?: string
   expectedKeywordInput?: string
-  consoleSpy?: ReturnType<typeof vi.spyOn>
+  consoleSpy?: MockInstance
 }) => {
   await waitFor(() => {
     // 1. 通信の検証

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -1,5 +1,6 @@
 import { expect, vi } from 'vitest'
 
+import { APP_PATHS } from '@shared/constants'
 import { ApiRequestSchema } from '@shared/schemas/api'
 import type { Keyword } from '@shared/schemas/keyword'
 
@@ -10,11 +11,17 @@ import { BookmarkApiError } from '../lib/api-client'
 export const mockNavigate = vi.fn()
 
 //  指定されたパスへの遷移が行われたことを検証する
-export const verifyNavigateToPath = (
-  path: string,
-  navigation: (url: string) => void = mockNavigate,
-) => {
-  expect(navigation).toHaveBeenCalledWith(path)
+export const verifyNavigateToPath = ({
+  path = APP_PATHS.HOME,
+  navigation = mockNavigate,
+  isNotCalled = false,
+}: {
+  path?: string
+  navigation?: (url: string) => void
+  isNotCalled?: boolean
+} = {}) => {
+  if (isNotCalled) expect(navigation).not.toHaveBeenCalledWith(path)
+  else expect(navigation).toHaveBeenCalledWith(path)
 }
 
 /**
@@ -98,7 +105,7 @@ export const verifySuccess = async ({
     }
 
     verifyCalledMessage({ action, payload })
-    if (path) verifyNavigateToPath(path)
+    if (path) verifyNavigateToPath({ path })
 
     if (extraAssertions) extraAssertions()
   })

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -1,4 +1,4 @@
-import { expect, vi } from 'vitest'
+import { expect, vi, type MockInstance } from 'vitest'
 
 import { APP_PATHS } from '@shared/constants'
 import { ApiRequestSchema } from '@shared/schemas/api'
@@ -12,7 +12,7 @@ export const mockNavigate = vi.fn()
 
 //  指定されたパスへの遷移が行われたことを検証する
 export const verifyNavigateToPath = ({
-  path = APP_PATHS.HOME,
+  path,
   navigation = mockNavigate,
   isNotCalled = false,
 }: {
@@ -20,8 +20,11 @@ export const verifyNavigateToPath = ({
   navigation?: (url: string) => void
   isNotCalled?: boolean
 } = {}) => {
-  if (isNotCalled) expect(navigation).not.toHaveBeenCalledWith(path)
-  else expect(navigation).toHaveBeenCalledWith(path)
+  const targetPath = path ?? APP_PATHS.HOME
+  if (isNotCalled) {
+    if (!path) expect(navigation).not.toHaveBeenCalled()
+    else expect(navigation).not.toHaveBeenCalledWith(targetPath)
+  } else expect(navigation).toHaveBeenCalledWith(targetPath)
 }
 
 /**
@@ -118,6 +121,7 @@ export const verifyError = async ({
   action,
   payload,
   expected,
+  navigateToPath,
   extraAssertions,
 }: {
   getHookState?: () => {
@@ -125,10 +129,15 @@ export const verifyError = async ({
     error: unknown
   }
   logMessage?: string
-  consoleSpy?: ReturnType<typeof vi.spyOn>
+  consoleSpy?: MockInstance
   action: string
   payload?: unknown
   expected: { message: string; code: string }
+  navigateToPath?: {
+    path?: string
+    navigation?: (url: string) => void
+    isNotCalled?: boolean
+  }
   extraAssertions?: () => void
 }) => {
   let error: unknown
@@ -154,6 +163,7 @@ export const verifyError = async ({
       expect(error).toBeInstanceOf(BookmarkApiError)
     }
 
+    if (navigateToPath) verifyNavigateToPath(navigateToPath)
     if (extraAssertions) extraAssertions()
   })
 }

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -106,31 +106,47 @@ export const verifySuccess = async ({
 
 export const verifyError = async ({
   getHookState,
+  logMessage,
+  consoleSpy,
   action,
   payload,
   expected,
   extraAssertions,
 }: {
-  getHookState: () => {
+  getHookState?: () => {
     isError?: boolean
     error: unknown
   }
+  logMessage?: string
+  consoleSpy?: ReturnType<typeof vi.spyOn>
   action: string
-  payload: unknown
+  payload?: unknown
   expected: { message: string; code: string }
   extraAssertions?: () => void
 }) => {
+  let error: unknown
+
   await waitFor(() => {
-    expect(getHookState().isError).toBe(true)
+    if (getHookState) {
+      error = getHookState().error
+      expect(getHookState().isError).toBe(true)
+    } else if (consoleSpy && logMessage) {
+      const call = consoleSpy.mock.calls.find(
+        (args: string[]) => args[0] === logMessage,
+      )
+      expect(call).toBeDefined()
+      error = call![1] // 2番目の引数がエラーオブジェクト
+    }
 
     verifyCalledMessage({ action, payload })
-    const error = getHookState().error
+
     if (error instanceof BookmarkApiError) {
       expect(error.message).toBe(expected.message)
       expect(error.code).toBe(expected.code)
     } else {
       expect(error).toBeInstanceOf(BookmarkApiError)
     }
+
     if (extraAssertions) extraAssertions()
   })
 }


### PR DESCRIPTION
## 概要
`useBookmarkPage.bookmark.test.ts` において、`handleUpdate` および `handleDelete` の API 通信失敗時の挙動を検証するテストを追加しました。

## 変更内容
- **ロジック検証**: 
    - 更新・削除失敗時のエラーログ出力（`LOG_MESSAGES`）の検証。
    - 失敗時に一覧画面へ遷移しない（`mockNavigate` が呼ばれない）ことの検証。
- **基盤改善 (`src/test/mock.ts`)**: 
    - `verifyError` ヘルパーを拡張し、`consoleSpy` によるログ検証と `navigateToPath` による非遷移検証をサポート。

## 関連 Issue
Close #572