### PR TITLE
[Refactor] useKeywordPage テストユーティリティ (test-utils.ts) の整備

### DIFF
--- a/src/hooks/useKeywordPage.test-utils.ts
+++ b/src/hooks/useKeywordPage.test-utils.ts
@@ -1,0 +1,49 @@
+import { expect, vi } from 'vitest'
+
+import { API_ACTIONS, APP_PATHS } from '@shared/constants'
+import type { Keyword } from '@shared/schemas/keyword'
+import { MOCK_KEYWORDS } from '@shared/test/fixtures'
+
+import { useKeywordPage } from './useKeywordPage'
+import { mockMessage } from '../test/messaging'
+import { renderHook, waitFor } from '../test/utils'
+
+// 1. 型定義のエクスポート
+export type MockParam = { action: string; params: unknown }
+
+// 2. setupHook: 初期化待ちを含めた共通セットアップ
+export const setupHook = async ({
+  mock,
+  keyword,
+  initialUrl,
+}: {
+  mock?: MockParam
+  keyword?: Keyword
+  initialUrl?: string
+} = {}) => {
+  if (mock) mockMessage(mock.action, mock.params)
+
+  const url =
+    initialUrl ?? (keyword ? APP_PATHS.KEYWORD_DETAIL(keyword.id) : undefined)
+  const { result } = renderHook(() => useKeywordPage(), { initialUrl: url })
+
+  await waitFor(() => {
+    expect(result.current.isLoading).toBe(false)
+    if (keyword) {
+      expect(result.current.keyword).toEqual(keyword)
+      expect(result.current.editName).toBe(keyword.name)
+    } else {
+      expect(result.current.keyword).toBeUndefined()
+    }
+  })
+  return result
+}
+
+// 3. commonSetup: beforeEach で呼び出す基本モック
+export const commonSetup = () => {
+  vi.clearAllMocks()
+  mockMessage(API_ACTIONS.READ_KEYWORDS, {
+    success: true,
+    data: { keywords: MOCK_KEYWORDS },
+  })
+}


### PR DESCRIPTION
## 概要
`useKeywordPage` フックのテストを機能ごとに分割して復旧するための共通ユーティリティを整備しました。

## 変更内容
- `src/hooks/useKeywordPage.test-utils.ts` を新規作成
- `setupHook`: 初期化待ち（isLoading, keyword, editName）を含めた共通セットアップロジックの実装
- `commonSetup`: `beforeEach` で利用する基本モック（READ_KEYWORDS）の実装
- 必要な型定義（`MockParam`）のエクスポート

## 関連 Issue
Close #571