### PR TITLE
[Infrastructure] ローカル D1 データベースの初期化とマイグレーションの動作検証

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ dist-extension/
 
 # Database migrations backup
 server/db/migrations_backup/
+
+.wrangler/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "type-check:extension": "tsc -p extension/tsconfig.json --noEmit",
     "prepare": "husky",
     "db:generate": "npx drizzle-kit generate",
-    "db:migrate:local": "wrangler d1 migrations apply bookmark-page-db --local",
+    "db:migrate:local": "wrangler d1 migrations apply bookmark-page-db --local -y",
     "db:studio": "npx drizzle-kit studio"
   },
   "lint-staged": {


### PR DESCRIPTION
Closes #598

## 変更内容
- `npm run db:migrate:local` スクリプトに `-y` オプションを追加し、非対話的にマイグレーションを適用できるように変更しました。
- ローカル D1 環境におけるマイグレーション適用および `wrangler dev` サーバーの正常起動を確認しました。