### PR TITLE
[Verification] ローカル実機環境の結合検証

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 # バックエンド CORS 許可設定用
-BOOKMARK_PAGE_FRONTEND_URL=http://localhost:5173
+BOOKMARK_PAGE_FRONTEND_URL=http://localhost:5180
 
 # ブラウザ拡張機能との連携用 ID
 VITE_EXTENSION_ID=your-extension-id-here
 
-# サーバーの起動ポート番号 (デフォルト: 3030)
-# SERVER_PORT=3030
+# サーバーの起動ポート番号 (デフォルト: 8787)
+# SERVER_PORT=8787
 
 # データベースファイル名の指定 (デフォルト: bookmarks.sqlite)
 # DB_FILENAME=my-custom-database.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ dist-extension/
 server/db/migrations_backup/
 
 .wrangler/
+.dev.vars

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ import importX from 'eslint-plugin-import-x'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage']),
+  globalIgnores(['dist', 'coverage', '.wrangler', 'dist-extension']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -130,7 +130,7 @@ const bookmarksRoute = new Hono<{ Bindings: Bindings }>()
   })
   .delete(
     '/:id',
-    zValidator('param', z.object({ id: z.string().regex(/^[1-9]\d*$/) })),
+    zValidator('param', z.object({ id: BookmarkIdSchema })),
     async (c) => {
       const { id } = c.req.valid('param')
       // const bookmarkId = parseInt(id, 10)
@@ -164,7 +164,7 @@ const bookmarksRoute = new Hono<{ Bindings: Bindings }>()
   )
   .patch(
     '/:id',
-    zValidator('param', z.object({ id: z.string().regex(/^[1-9]\d*$/) })),
+    zValidator('param', z.object({ id: BookmarkIdSchema })),
     zValidator('json', updateBookmarkInputSchema),
     async (c) => {
       const { id } = c.req.valid('param')
@@ -267,7 +267,7 @@ const bookmarksRoute = new Hono<{ Bindings: Bindings }>()
   )
   .post(
     '/:id/keywords',
-    zValidator('param', z.object({ id: z.string().regex(/^[1-9]\d*$/) })),
+    zValidator('param', z.object({ id: BookmarkIdSchema })),
     zValidator('json', attachKeywordInputSchema),
     async (c) => {
       const { id: bookmarkId } = c.req.valid('param')
@@ -346,8 +346,8 @@ const bookmarksRoute = new Hono<{ Bindings: Bindings }>()
     zValidator(
       'param',
       z.object({
-        id: z.string().regex(/^[1-9]\d*$/),
-        keywordId: z.string().regex(/^[1-9]\d*$/),
+        id: BookmarkIdSchema,
+        keywordId: KeywordIdSchema,
       }),
     ),
     async (c) => {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -45,8 +45,8 @@ export const PLACEHOLDERS = {
  * デフォルトのポート番号
  */
 export const DEFAULT_PORTS = {
-  FRONTEND: 5173,
-  BACKEND: 3030,
+  FRONTEND: 5180,
+  BACKEND: 8787,
 } as const
 
 /**


### PR DESCRIPTION
Closes #599

## 変更内容
- **不具合修正**:
  - `server/routes/bookmarks.ts` において、移行前の数値ID検証正規表現 (`z.string().regex(/^[1-9]\d*$/)`) が残っており、UUID v7 による削除やキーワード紐付けの API パラメータ検証が 400 Bad Request で失敗していた問題を修正。UUID 形式 (`BookmarkIdSchema`, `KeywordIdSchema`) を検証するように変更。
- **設定更新**:
  - フロントエンドのデフォルトポートを `5180` に、Wrangler (D1) のデフォルトポートを `8787` に変更。
  - `.gitignore` に Wrangler のローカル環境変数ファイル `.dev.vars` を追加。
  - `eslint.config.js` の無視リストに `.wrangler` および `dist-extension` を追加。
- **検証結果**:
  - ローカル D1 および Web アプリ/拡張機能が正常に連携し、CRUD 操作およびキーワード紐付けができることを実機確認しました。