### PR TITLE
feat: add migration script for SQLite to D1 and unit tests (#600)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ server/db/migrations_backup/
 
 .wrangler/
 .dev.vars
+d1-import.sql

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
         "@types/chrome": "^0.1.40",
-        "@types/node": "^25.6.0",
+        "@types/node": "^25.9.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
     "@types/chrome": "^0.1.40",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.9.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/scripts/migrate-data.test.ts
+++ b/scripts/migrate-data.test.ts
@@ -1,0 +1,66 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import { generateMigrationSql } from './migrate-data'
+
+describe('migrate-data', () => {
+  const testDbPath = path.join(process.cwd(), 'test-migrate.sqlite')
+  const testOutputPath = path.join(process.cwd(), 'test-d1-import.sql')
+
+  beforeEach(() => {
+    // テスト用の SQLite DB を作成
+    const db = new DatabaseSync(testDbPath)
+    db.exec(`
+       CREATE TABLE bookmarks (
+         bookmark_id INTEGER PRIMARY KEY AUTOINCREMENT,
+         url TEXT NOT NULL UNIQUE,
+         title TEXT NOT NULL,
+         sort_order INTEGER DEFAULT 0 NOT NULL
+       );
+       CREATE TABLE keywords (
+         keyword_id INTEGER PRIMARY KEY AUTOINCREMENT,
+         keyword_name TEXT NOT NULL UNIQUE
+       );
+       CREATE TABLE bookmark_keywords (
+         bookmark_keyword_id INTEGER PRIMARY KEY AUTOINCREMENT,
+         bookmark_id INTEGER NOT NULL,
+         keyword_id INTEGER NOT NULL
+       );
+
+       INSERT INTO bookmarks (url, title, sort_order) VALUES ('https://example.com', 'Example', 1);
+       INSERT INTO keywords (keyword_name) VALUES ('test-tag');
+       INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (1, 1);
+     `)
+    db.close()
+  })
+
+  afterEach(() => {
+    if (fs.existsSync(testDbPath)) fs.unlinkSync(testDbPath)
+    if (fs.existsSync(testOutputPath)) fs.unlinkSync(testOutputPath)
+  })
+
+  it('SQLite から D1 用の SQL を正しく生成できること', () => {
+    const stats = generateMigrationSql(testDbPath, testOutputPath)
+
+    expect(stats.bookmarksCount).toBe(1)
+    expect(stats.keywordsCount).toBe(1)
+    expect(stats.relationsCount).toBe(1)
+
+    const sqlContent = fs.readFileSync(testOutputPath, 'utf-8')
+    expect(sqlContent).toContain('INSERT INTO bookmarks')
+    expect(sqlContent).toContain('https://example.com')
+    expect(sqlContent).toContain('Example')
+    expect(sqlContent).toContain('INSERT INTO keywords')
+    expect(sqlContent).toContain('test-tag')
+    expect(sqlContent).toContain('INSERT INTO bookmark_keywords')
+  })
+
+  it('存在しない DB パスが指定された場合にエラーを投げること', () => {
+    expect(() =>
+      generateMigrationSql('non-existent.sqlite', testOutputPath),
+    ).toThrow()
+  })
+})

--- a/scripts/migrate-data.ts
+++ b/scripts/migrate-data.ts
@@ -4,8 +4,9 @@ import { DatabaseSync } from 'node:sqlite'
 import { fileURLToPath } from 'node:url' // 追加
 
 import { uuidv7 } from 'uuidv7'
+import { z } from 'zod'
 
-import { DB_CONSTANTS } from '../shared/constants'
+import { DB_CONSTANTS, LOG_MESSAGES } from '../shared/constants'
 
 // デフォルトのパス設定
 const DEFAULT_DB_PATH = path.join(process.cwd(), DB_CONSTANTS.FILENAME)
@@ -22,17 +23,18 @@ export function generateMigrationSql(
     throw new Error(`Error: Old database file not found at ${dbPath}`)
   }
 
-  console.log(`Reading old database from ${dbPath}...`)
+  console.log(`LOG_MESSAGES.MIGRATION_READING_DB(${dbPath})`)
   const db = new DatabaseSync(dbPath)
 
   // 1. ブックマークの読み込みとマッピング
   const bookmarksQuery = db.prepare('SELECT * FROM bookmarks')
-  const oldBookmarks = bookmarksQuery.all() as {
-    bookmark_id: number
-    url: string
-    title: string
-    sort_order: number
-  }[]
+  const BookmarkSchema = z.object({
+    bookmark_id: z.number(),
+    url: z.string(),
+    title: z.string(),
+    sort_order: z.number(),
+  })
+  const oldBookmarks = z.array(BookmarkSchema).parse(bookmarksQuery.all())
 
   const bookmarkMap = new Map<number, string>()
   const bookmarkSqls: string[] = []
@@ -49,10 +51,11 @@ export function generateMigrationSql(
 
   // 2. キーワードの読み込みとマッピング
   const keywordsQuery = db.prepare('SELECT * FROM keywords')
-  const oldKeywords = keywordsQuery.all() as {
-    keyword_id: number
-    keyword_name: string
-  }[]
+  const KeywordSchema = z.object({
+    keyword_id: z.number(),
+    keyword_name: z.string(),
+  })
+  const oldKeywords = z.array(KeywordSchema).parse(keywordsQuery.all())
 
   const keywordMap = new Map<number, string>()
   const keywordSqls: string[] = []
@@ -68,11 +71,12 @@ export function generateMigrationSql(
 
   // 3. ブックマークとキーワードの関連付け
   const relationsQuery = db.prepare('SELECT * FROM bookmark_keywords')
-  const oldRelations = relationsQuery.all() as {
-    bookmark_keyword_id: number
-    bookmark_id: number
-    keyword_id: number
-  }[]
+  const RelationSchema = z.object({
+    bookmark_keyword_id: z.number(),
+    bookmark_id: z.number(),
+    keyword_id: z.number(),
+  })
+  const oldRelations = z.array(RelationSchema).parse(relationsQuery.all())
 
   const relationSqls: string[] = []
 
@@ -88,7 +92,7 @@ export function generateMigrationSql(
     } else {
       // 修正ポイント: テンプレートリテラルのタイポを修正
       console.warn(
-        `Warning: Broken relation found in old db: bookmark_id=${r.bookmark_id}, keyword_id=${r.keyword_id}`,
+        LOG_MESSAGES.MIGRATION_BROKEN_RELATION(r.bookmark_id, r.keyword_id),
       )
     }
   }
@@ -125,10 +129,10 @@ const isMain = process.argv[1] === path.resolve(__filename) // 変更
 if (isMain) {
   try {
     const stats = generateMigrationSql()
-    console.log(`\nMigration SQL generated successfully!`)
-    console.log(`Total Bookmarks: ${stats.bookmarksCount}`)
-    console.log(`Total Keywords: ${stats.keywordsCount}`)
-    console.log(`Total Relations: ${stats.relationsCount}`)
+    console.log(LOG_MESSAGES.MIGRATION_SUCCESS)
+    console.log(LOG_MESSAGES.MIGRATION_TOTAL_BOOKMARKS(stats.bookmarksCount))
+    console.log(LOG_MESSAGES.MIGRATION_TOTAL_KEYWORDS(stats.keywordsCount))
+    console.log(LOG_MESSAGES.MIGRATION_TOTAL_RELATIONS(stats.relationsCount))
   } catch (error) {
     if (error instanceof Error) {
       console.error(error.message)

--- a/scripts/migrate-data.ts
+++ b/scripts/migrate-data.ts
@@ -1,0 +1,138 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { fileURLToPath } from 'node:url' // 追加
+
+import { uuidv7 } from 'uuidv7'
+
+import { DB_CONSTANTS } from '../shared/constants'
+
+// デフォルトのパス設定
+const DEFAULT_DB_PATH = path.join(process.cwd(), DB_CONSTANTS.FILENAME)
+const DEFAULT_OUTPUT_PATH = path.join(process.cwd(), 'd1-import.sql')
+
+/**
+ * SQLite データベースから D1 用の Migration SQL を生成する
+ */
+export function generateMigrationSql(
+  dbPath: string = DEFAULT_DB_PATH,
+  outputPath: string = DEFAULT_OUTPUT_PATH,
+) {
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`Error: Old database file not found at ${dbPath}`)
+  }
+
+  console.log(`Reading old database from ${dbPath}...`)
+  const db = new DatabaseSync(dbPath)
+
+  // 1. ブックマークの読み込みとマッピング
+  const bookmarksQuery = db.prepare('SELECT * FROM bookmarks')
+  const oldBookmarks = bookmarksQuery.all() as {
+    bookmark_id: number
+    url: string
+    title: string
+    sort_order: number
+  }[]
+
+  const bookmarkMap = new Map<number, string>()
+  const bookmarkSqls: string[] = []
+
+  for (const b of oldBookmarks) {
+    const newUuid = uuidv7()
+    bookmarkMap.set(b.bookmark_id, newUuid)
+    const titleEscaped = b.title.replace(/'/g, "''")
+    const urlEscaped = b.url.replace(/'/g, "''")
+    bookmarkSqls.push(
+      `INSERT INTO bookmarks (id, url, title, sort_order) VALUES ('${newUuid}', '${urlEscaped}', '${titleEscaped}', ${b.sort_order});`,
+    )
+  }
+
+  // 2. キーワードの読み込みとマッピング
+  const keywordsQuery = db.prepare('SELECT * FROM keywords')
+  const oldKeywords = keywordsQuery.all() as {
+    keyword_id: number
+    keyword_name: string
+  }[]
+
+  const keywordMap = new Map<number, string>()
+  const keywordSqls: string[] = []
+
+  for (const k of oldKeywords) {
+    const newUuid = uuidv7()
+    keywordMap.set(k.keyword_id, newUuid)
+    const nameEscaped = k.keyword_name.replace(/'/g, "''")
+    keywordSqls.push(
+      `INSERT INTO keywords (id, name) VALUES ('${newUuid}', '${nameEscaped}');`,
+    )
+  }
+
+  // 3. ブックマークとキーワードの関連付け
+  const relationsQuery = db.prepare('SELECT * FROM bookmark_keywords')
+  const oldRelations = relationsQuery.all() as {
+    bookmark_keyword_id: number
+    bookmark_id: number
+    keyword_id: number
+  }[]
+
+  const relationSqls: string[] = []
+
+  for (const r of oldRelations) {
+    const newBookmarkUuid = bookmarkMap.get(r.bookmark_id)
+    const newKeywordUuid = keywordMap.get(r.keyword_id)
+
+    if (newBookmarkUuid && newKeywordUuid) {
+      const relationUuid = uuidv7()
+      relationSqls.push(
+        `INSERT INTO bookmark_keywords (id, bookmark_id, keyword_id) VALUES ('${relationUuid}', '${newBookmarkUuid}', '${newKeywordUuid}');`,
+      )
+    } else {
+      // 修正ポイント: テンプレートリテラルのタイポを修正
+      console.warn(
+        `Warning: Broken relation found in old db: bookmark_id=${r.bookmark_id}, keyword_id=${r.keyword_id}`,
+      )
+    }
+  }
+
+  // 4. SQLファイルの出力
+  const sqlContent = [
+    '-- D1 Migration Script',
+    `-- Generated on ${new Date().toISOString()}`,
+    '',
+    '-- Bookmarks',
+    ...bookmarkSqls,
+    '',
+    '-- Keywords',
+    ...keywordSqls,
+    '',
+    '-- Bookmark Keywords',
+    ...relationSqls,
+  ].join('\n')
+
+  fs.writeFileSync(outputPath, sqlContent, 'utf-8')
+
+  return {
+    bookmarksCount: bookmarkSqls.length,
+    keywordsCount: keywordSqls.length,
+    relationsCount: relationSqls.length,
+  }
+}
+
+// 直接実行された場合の処理
+//  const isMain = process.argv[1] === path.resolve(import.meta.filename)
+const __filename = fileURLToPath(import.meta.url) // 追加
+const isMain = process.argv[1] === path.resolve(__filename) // 変更
+
+if (isMain) {
+  try {
+    const stats = generateMigrationSql()
+    console.log(`\nMigration SQL generated successfully!`)
+    console.log(`Total Bookmarks: ${stats.bookmarksCount}`)
+    console.log(`Total Keywords: ${stats.keywordsCount}`)
+    console.log(`Total Relations: ${stats.relationsCount}`)
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message)
+    }
+    process.exit(1)
+  }
+}

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -440,6 +440,14 @@ export const LOG_MESSAGES = {
     `Action ${action} is not yet implemented.`,
   UNKNOWN_ACTION: 'Unknown action received.',
   INVALID_PAYLOAD: (message: string) => `Invalid payload: ${message}`,
+  MIGRATION_READING_DB: (path: string) =>
+    `Reading old database from ${path}...`,
+  MIGRATION_BROKEN_RELATION: (bookmarkId: number, keywordId: number) =>
+    `Warning: Broken relation found in old db: bookmark_id=${bookmarkId}, keyword_id=${keywordId}`,
+  MIGRATION_SUCCESS: '\nMigration SQL generated successfully!',
+  MIGRATION_TOTAL_BOOKMARKS: (count: number) => `Total Bookmarks: ${count}`,
+  MIGRATION_TOTAL_KEYWORDS: (count: number) => `Total Keywords: ${count}`,
+  MIGRATION_TOTAL_RELATIONS: (count: number) => `Total Relations: ${count}`,
 } as const
 
 /**

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -7,10 +7,10 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
-    "types": ["chrome", "@cloudflare/workers-types"],
+    "types": ["node", "chrome", "@cloudflare/workers-types"],
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["server", "shared"],
+  "include": ["server", "shared", "scripts"],
   "exclude": ["shared/components/ui"]
 }


### PR DESCRIPTION
## 概要
旧環境の SQLite ファイルからデータをエクスポートし、D1 への移行用 SQL を生成するスクリプトを実装しました。

## 変更内容
- `scripts/migrate-data.ts`: SQLite から D1 への移行 SQL 生成スクリプトの実装
- `scripts/migrate-data.test.ts`: 移行スクリプトのユニットテストを追加
- `tsconfig.server.json`: `scripts/` ディレクトリを型チェック対象に追加
- `.gitignore`: 生成される `d1-import.sql` を除外設定に追加

## 検証結果
- `npm run lint`: パス
- `npm run type-check`: パス
- `npx vitest scripts/migrate-data.test.ts`: 2件のテストがパス
- 実際の `bookmarks.sqlite` を使用した SQL 生成の動作確認済み