### PR TITLE
fix: db:migrate:local スクリプトの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "type-check:extension": "tsc -p extension/tsconfig.json --noEmit",
     "prepare": "husky",
     "db:generate": "npx drizzle-kit generate",
-    "db:migrate:local": "wrangler d1 migrations apply bookmark-page-db --local -y",
+    "db:migrate:local": "wrangler d1 migrations apply bookmark-page-db --local",
     "db:studio": "npx drizzle-kit studio"
   },
   "lint-staged": {


### PR DESCRIPTION
wrangler d1 migrations apply コマンドでサポートされていない -y フラグを削除しました。これにより、新規環境でのセットアップ時に発生していたエラーが解消されます。