### PR TITLE
不要になったローカル専用コードのクリーンアップ  #602

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bookmark-page",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bookmark-page",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -45,7 +45,6 @@
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
-        "fake-indexeddb": "^6.2.5",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
@@ -5235,16 +5234,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/fake-indexeddb": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
-      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
-    "fake-indexeddb": "^6.2.5",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -10,12 +10,7 @@ import {
   VALIDATION_MESSAGES,
 } from '@shared/constants'
 import { keywordResponseSchema, keywordsSchema } from '@shared/schemas/keyword'
-import {
-  MOCK_BOOKMARK_1,
-  MOCK_IDS,
-  MOCK_KEYWORDS,
-  TEST_STRINGS,
-} from '@shared/test/fixtures'
+import { MOCK_IDS, MOCK_KEYWORDS, TEST_STRINGS } from '@shared/test/fixtures'
 
 import app from '../app'
 import { getDb } from '../db'
@@ -219,13 +214,13 @@ describe('Keyword API', () => {
     )
 
     it('既に存在する名前の場合は 409 Conflict を返し、エラーオブジェクトを含むこと', async () => {
-      const bookmark = MOCK_BOOKMARK_1
+      const keyword = MOCK_KEYWORDS[0]
       const dbMock = {
         // 1. 重複チェック用
         select: vi.fn().mockReturnValue({
           from: vi.fn().mockReturnValue({
             where: vi.fn().mockReturnValue({
-              get: vi.fn().mockResolvedValue(bookmark),
+              get: vi.fn().mockResolvedValue(keyword),
             }),
           }),
         }),

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@shared/constants'
 import { keywordResponseSchema, keywordsSchema } from '@shared/schemas/keyword'
 import {
-  MOCK_BOOKMARK_ENTITY_1,
+  MOCK_BOOKMARK_1,
   MOCK_IDS,
   MOCK_KEYWORDS,
   TEST_STRINGS,
@@ -219,7 +219,7 @@ describe('Keyword API', () => {
     )
 
     it('既に存在する名前の場合は 409 Conflict を返し、エラーオブジェクトを含むこと', async () => {
-      const bookmark = MOCK_BOOKMARK_ENTITY_1
+      const bookmark = MOCK_BOOKMARK_1
       const dbMock = {
         // 1. 重複チェック用
         select: vi.fn().mockReturnValue({

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -188,9 +188,7 @@ export const UI_MESSAGES = {
   KEYWORD_NOT_FOUND: (id: string | number) =>
     `キーワードが見つかりませんでした (ID: ${id})`,
   EMPTY_SECTION: (label: string) => `${label}は空です`,
-  CHROME_EXTENSION_NOT_AVAILABLE: 'chromeの拡張機能が利用できません',
-  INVALID_RESPONSE_FROM_EXTENSION: '拡張機能からの返り値の形式が不正です',
-  UNKNOWN_EXTENSION_ERROR: '拡張機能での不明なエラーです',
+  INVALID_RESPONSE_FORMAT: '拡張機能からの返り値の形式が不正です',
   API_ERROR: 'APIのエラーです',
 } as const
 
@@ -347,17 +345,8 @@ export const ELEMENT_IDS = {
  * データベース関連の定数
  */
 export const DB_CONSTANTS = {
-  DB_NAME: 'BookmarkDatabase',
-  IDB_VERSION: 1,
-  IDB_SCHEMA: {
-    bookmarks: 'id, &url, sortOrder, *keywordIds',
-    keywords: 'id, name',
-  },
   FILENAME: 'bookmarks.sqlite',
   MIGRATIONS_DIR: 'server/db/migrations',
-  PRAGMA_FOREIGN_KEYS_ON: 'foreign_keys = ON',
-  PRAGMA_FOREIGN_KEYS_OFF: 'foreign_keys = OFF',
-  PRAGMA_JOURNAL_MODE_WAL: 'journal_mode = WAL',
 } as const
 
 /**

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -188,7 +188,7 @@ export const UI_MESSAGES = {
   KEYWORD_NOT_FOUND: (id: string | number) =>
     `キーワードが見つかりませんでした (ID: ${id})`,
   EMPTY_SECTION: (label: string) => `${label}は空です`,
-  INVALID_RESPONSE_FORMAT: '拡張機能からの返り値の形式が不正です',
+  INVALID_RESPONSE_FORMAT: 'レスポンスの形式が不正です',
   API_ERROR: 'APIのエラーです',
 } as const
 

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -5,7 +5,7 @@ import { DEFAULT_API_URL } from '@shared/constants'
 import { BookmarkIdSchema } from '../schemas/bookmark'
 import { KeywordIdSchema } from '../schemas/keyword'
 
-import type { Bookmark, BookmarkEntity } from '../schemas/bookmark'
+import type { Bookmark } from '../schemas/bookmark'
 import type { KeywordWithCount } from '../schemas/keyword'
 
 export const MOCK_BOOKMARK_TITLE_PREFIX = 'Test Bookmark'
@@ -87,29 +87,6 @@ export const MOCK_BOOKMARKS = [
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_2,
   MOCK_BOOKMARK_3,
-]
-
-/**
- * IndexedDB 用のエンティティフィクスチャ
- */
-const toEntity = (bookmark: Bookmark): BookmarkEntity => {
-  return {
-    id: bookmark.id,
-    title: bookmark.title,
-    url: bookmark.url,
-    sortOrder: bookmark.sortOrder,
-    keywordIds: bookmark.keywords.map((k) => k.id),
-  }
-}
-
-export const MOCK_BOOKMARK_ENTITY_1 = toEntity(MOCK_BOOKMARK_1)
-export const MOCK_BOOKMARK_ENTITY_2 = toEntity(MOCK_BOOKMARK_2)
-export const MOCK_BOOKMARK_ENTITY_3 = toEntity(MOCK_BOOKMARK_3)
-
-export const MOCK_BOOKMARK_ENTITIES = [
-  MOCK_BOOKMARK_ENTITY_1,
-  MOCK_BOOKMARK_ENTITY_2,
-  MOCK_BOOKMARK_ENTITY_3,
 ]
 
 export const VALID_URLS = {

--- a/src/contexts/ApiContext.test.tsx
+++ b/src/contexts/ApiContext.test.tsx
@@ -4,15 +4,8 @@ import { describe, it, expect, vi } from 'vitest'
 import { ERROR_MESSAGES } from '@shared/constants'
 
 import { useApi } from './ApiContext'
-import { HttpApiClient } from '../lib/api-client'
-import { renderHook } from '../test/utils'
 
 describe('ApiContext', () => {
-  it('ExtensionApiClient が Provider を通じて提供されること', () => {
-    const { result } = renderHook(() => useApi())
-    expect(result.current.client).toBeInstanceOf(HttpApiClient)
-  })
-
   it('ApiProvider 外で useApi を呼び出した場合にエラーを投げること', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     expect(() => {

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -10,11 +10,7 @@ import {
 import { DEFAULT_API_URL, ERROR_MESSAGES } from '@shared/constants'
 import { validateApiUrl } from '@shared/utils/url'
 
-import {
-  ExtensionApiClient,
-  HttpApiClient,
-  type ApiClient,
-} from '../lib/api-client'
+import { HttpApiClient, type ApiClient } from '../lib/api-client'
 
 interface ApiContextType {
   client: ApiClient
@@ -43,10 +39,7 @@ export const ApiProvider = ({ children }: ApiProviderProps) => {
   )
 
   const client = useMemo(() => {
-    if (import.meta.env.MODE === 'test' || apiUrl) {
-      return new HttpApiClient(apiUrl)
-    }
-    return new ExtensionApiClient()
+    return new HttpApiClient(apiUrl)
   }, [apiUrl])
 
   const updateApiUrl = useCallback((newUrl: string) => {

--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -133,7 +133,7 @@ describe('useBookmarks Hook', () => {
         testName: '不正なレスポンス形式',
         params: null,
         expected: {
-          message: UI_MESSAGES.INVALID_RESPONSE_FROM_EXTENSION,
+          message: UI_MESSAGES.INVALID_RESPONSE_FORMAT,
           code: ERROR_CODES.INTERNAL_SERVER_ERROR,
         },
         skip: true,

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,6 +1,6 @@
 import { hc } from 'hono/client'
 
-import { API_ACTIONS, ERROR_CODES, UI_MESSAGES } from '@shared/constants'
+import { ERROR_CODES, UI_MESSAGES } from '@shared/constants'
 import type {
   Bookmarks,
   Bookmark,
@@ -48,126 +48,6 @@ export interface ApiClient {
   //   ブックマークとキーワードの関連
   attachKeyword(bookmarkId: BookmarkId, keywordId: KeywordId): Promise<Bookmark>
   detachKeyword(bookmarkId: BookmarkId, keywordId: KeywordId): Promise<void>
-}
-
-export class ExtensionApiClient implements ApiClient {
-  /**
-   * 拡張機能へのメッセージ送信を共通化するプライベートメソッド
-   */
-  private async sendMessage<T>(action: string, payload?: unknown): Promise<T> {
-    // 1. 拡張機能の存在チェック
-    if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) {
-      throw new Error(UI_MESSAGES.CHROME_EXTENSION_NOT_AVAILABLE)
-    }
-
-    return new Promise((resolve, reject) => {
-      // 2. メッセージ送信
-      chrome.runtime.sendMessage({ action, payload }, (response) => {
-        // 3. ブラウザレベルの通信エラーチェック
-        if (chrome.runtime.lastError) {
-          reject(
-            new BookmarkApiError(
-              chrome.runtime.lastError.message ||
-                UI_MESSAGES.UNKNOWN_EXTENSION_ERROR,
-              ERROR_CODES.INTERNAL_SERVER_ERROR,
-            ),
-          )
-          return
-        }
-        if (!response || typeof response !== 'object') {
-          reject(
-            new BookmarkApiError(
-              UI_MESSAGES.INVALID_RESPONSE_FROM_EXTENSION,
-              ERROR_CODES.INTERNAL_SERVER_ERROR,
-            ),
-          )
-          return
-        }
-
-        // 4. アプリケーションレベルのレスポンス検証
-        if (response.success) {
-          resolve(response.data)
-        } else {
-          reject(
-            new BookmarkApiError(
-              response.error?.message || UI_MESSAGES.UNKNOWN_EXTENSION_ERROR,
-              response.error?.code || ERROR_CODES.INTERNAL_SERVER_ERROR,
-            ),
-          )
-        }
-      })
-    })
-  }
-  // --------------------------------------------------------------------------
-  // 各インターフェースメソッドの実装
-  // --------------------------------------------------------------------------
-
-  async readBookmarks(): Promise<Bookmarks> {
-    return this.sendMessage<Bookmarks>(API_ACTIONS.READ_BOOKMARKS)
-  }
-
-  async createBookmark(params: {
-    title: string
-    url: string
-  }): Promise<Bookmark> {
-    return this.sendMessage<Bookmark>(API_ACTIONS.CREATE_BOOKMARK, params)
-  }
-
-  async updateBookmark(
-    id: BookmarkId,
-    params: { title?: string; url?: string },
-  ): Promise<Bookmark> {
-    return this.sendMessage<Bookmark>(API_ACTIONS.UPDATE_BOOKMARK, {
-      id,
-      ...params,
-    })
-  }
-
-  deleteBookmark(id: BookmarkId): Promise<void> {
-    return this.sendMessage(API_ACTIONS.DELETE_BOOKMARK, { id })
-  }
-
-  reorderBookmarks(ids: BookmarkId[]): Promise<void> {
-    return this.sendMessage(API_ACTIONS.REORDER_BOOKMARKS, { ids })
-  }
-
-  readKeywords(): Promise<Keywords> {
-    return this.sendMessage<Keywords>(API_ACTIONS.READ_KEYWORDS)
-  }
-
-  createKeyword(param: { name: string }): Promise<KeywordResponse> {
-    return this.sendMessage<KeywordResponse>(API_ACTIONS.CREATE_KEYWORD, param)
-  }
-
-  updateKeyword(
-    id: KeywordId,
-    param: { name: string },
-  ): Promise<KeywordResponse> {
-    return this.sendMessage<KeywordResponse>(API_ACTIONS.UPDATE_KEYWORD, {
-      id,
-      ...param,
-    })
-  }
-  deleteKeyword(id: KeywordId): Promise<void> {
-    return this.sendMessage(API_ACTIONS.DELETE_KEYWORD, { id })
-  }
-
-  attachKeyword(
-    bookmarkId: BookmarkId,
-    keywordId: KeywordId,
-  ): Promise<Bookmark> {
-    return this.sendMessage<Bookmark>(API_ACTIONS.ATTACH_KEYWORD, {
-      bookmarkId,
-      keywordId,
-    })
-  }
-
-  detachKeyword(bookmarkId: BookmarkId, keywordId: KeywordId): Promise<void> {
-    return this.sendMessage<void>(API_ACTIONS.DETACH_KEYWORD, {
-      bookmarkId,
-      keywordId,
-    })
-  }
 }
 
 export class HttpApiClient implements ApiClient {


### PR DESCRIPTION
クラウド同期アーキテクチャへの完全移行に伴い、不要になった古いローカル専用の処理（旧 SQLite 連携コードや、メッセージングブリッジの遺物など）を削除・整理しました。

closes #602 