### PR TITLE
test: テストコード内のハードコードされた拡張機能IDをダミーIDに差し替えた

### DIFF
--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -6,7 +6,7 @@ import {
   ERROR_MESSAGES,
   HTTP_STATUS,
 } from '@shared/constants'
-import { INVALID_URLS } from '@shared/test/fixtures'
+import { INVALID_URLS, VALID_URLS } from '@shared/test/fixtures'
 
 import app from './app'
 import { createD1Mock, validateErrorResponse } from './test/testUtils'
@@ -42,8 +42,7 @@ describe('App Global Handlers', () => {
   describe('CORS', () => {
     const allowedOrigin = DEFAULT_FRONTEND_URL
     const untrustedOrigin = INVALID_URLS.UNTRUST_HTTP
-    const extensionOrigin =
-      'chrome-extension://fgjpgmalcecblhkciahpillnieljphgh'
+    const extensionOrigin = VALID_URLS.EXTENSION_ID
 
     it.each([
       {

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -98,6 +98,7 @@ export const VALID_URLS = {
   FRONTEND: 'http://localhost:5173',
   TEST_API: 'http://localhost:4000',
   CHROME_SETTING: 'chrome://settings',
+  EXTENSION_ID: 'chrome-extension://dummy-extension-id-for-testing',
 } as const
 
 /**


### PR DESCRIPTION
server/app.test.ts 内に本物の拡張機能IDがハードコードされて GitHub に公開されてしまっているため、これをダミーのID（chrome-extension://dummy-extension-id-for-testing）に差し替えました。

closes #627 