### PR TITLE
fix: 比較対象のハードコートされた文字列が間違っていたため定義済みの文字列を使うように修正した

### DIFF
--- a/extension/src/hooks/usePopup.test.ts
+++ b/extension/src/hooks/usePopup.test.ts
@@ -12,6 +12,7 @@ import {
   BOOKMARK_STATUS,
   EXTENSION_MESSAGE_TYPES,
   DEFAULT_API_URL,
+  DEFAULT_FRONTEND_URL,
 } from '@shared/constants'
 import {
   INVALID_URLS,
@@ -39,7 +40,7 @@ vi.stubGlobal('chrome', mockChrome)
 vi.stubGlobal('window', { close: vi.fn() })
 
 describe('usePopup Hook', () => {
-  const mockFrontendUrl = DEFAULT_API_URL
+  const mockFrontendUrl = DEFAULT_FRONTEND_URL
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/extension/src/hooks/usePopup.test.ts
+++ b/extension/src/hooks/usePopup.test.ts
@@ -16,7 +16,9 @@ import {
 import {
   INVALID_URLS,
   MOCK_BOOKMARK_1,
+  MOCK_BOOKMARK_2,
   MOCK_BOOKMARK_TITLE_PREFIX,
+  TEST_STRINGS,
   VALID_URLS,
 } from '@shared/test/fixtures'
 
@@ -37,7 +39,7 @@ vi.stubGlobal('chrome', mockChrome)
 vi.stubGlobal('window', { close: vi.fn() })
 
 describe('usePopup Hook', () => {
-  const mockFrontendUrl = 'http://localhost:5173'
+  const mockFrontendUrl = DEFAULT_API_URL
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -58,10 +60,8 @@ describe('usePopup Hook', () => {
       if (message.type === EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS) {
         callback({
           success: true,
-          data: {
-            status: BOOKMARK_STATUS.REGISTERED,
-            bookmarkId: MOCK_BOOKMARK_1.id,
-          },
+          status: BOOKMARK_STATUS.REGISTERED,
+          bookmarkId: MOCK_BOOKMARK_1.id,
         })
       }
     })
@@ -72,6 +72,29 @@ describe('usePopup Hook', () => {
       expect(result.current.title).toBe(MOCK_BOOKMARK_TITLE_PREFIX)
       expect(result.current.url).toBe(MOCK_BOOKMARK_1.url)
       expect(result.current.isRegistered).toBe(true)
+    })
+  })
+
+  it('未登録のタブを開いているとき、未登録の情報を取得できること', async () => {
+    mockChrome.tabs.query.mockResolvedValue([
+      { title: TEST_STRINGS.NEW_NAME, url: MOCK_BOOKMARK_2.url },
+    ])
+
+    mockChrome.runtime.sendMessage.mockImplementation((message, callback) => {
+      if (message.type === EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS) {
+        callback({
+          success: true,
+          status: BOOKMARK_STATUS.NONE,
+        })
+      }
+    })
+
+    const { result } = renderHook(() => usePopup())
+
+    await vi.waitFor(() => {
+      expect(result.current.title).toBe(TEST_STRINGS.NEW_NAME)
+      expect(result.current.url).toBe(MOCK_BOOKMARK_2.url)
+      expect(result.current.isRegistered).toBe(false)
     })
   })
 

--- a/extension/src/hooks/usePopup.ts
+++ b/extension/src/hooks/usePopup.ts
@@ -13,6 +13,7 @@ import {
   UI_STATUS,
   EXTENSION_MESSAGE_TYPES,
   type StatusInfo,
+  BOOKMARK_STATUS,
 } from '@shared/constants'
 import { createBookmarkInputSchema } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
@@ -57,7 +58,7 @@ export const usePopup = () => {
             },
             (response) => {
               if (isMounted && response?.success) {
-                setIsRegistered(response.status !== 'NONE')
+                setIsRegistered(response.status !== BOOKMARK_STATUS.NONE)
                 setRegisteredId(response.bookmarkId || null)
               }
             },


### PR DESCRIPTION
ハードコートされていた文字列: 'none'
定義済みの文字列: shared/constants.tsのBOOKMARK_STATUS.NONE = 'none'

closes: #632 